### PR TITLE
fix peraa keyword

### DIFF
--- a/prospect/models/sedmodel.py
+++ b/prospect/models/sedmodel.py
@@ -56,7 +56,7 @@ class SedModel(ProspectorParams):
             s *= self.spec_calibration(obs=obs, **extras)
         return s, p, x
     
-    def sed(self, theta, obs, sps=None, **kwargs):
+    def sed(self, theta, obs, sps=None, peraa=False, **kwargs):
         """
         Given a theta vector, generate a spectrum, photometry, and any
         extras (e.g. stellar mass), ***not** including any instrument
@@ -84,6 +84,7 @@ class SedModel(ProspectorParams):
         self.set_parameters(theta)        
         spec, phot, extras = sps.get_spectrum(outwave=obs['wavelength'],
                                               filters=obs['filters'],
+                                              peraa=peraa,
                                               **self.params)
         
         spec *= obs.get('normalization_guess', 1.0)

--- a/prospect/sources/ssp_basis.py
+++ b/prospect/sources/ssp_basis.py
@@ -194,7 +194,7 @@ class SSPBasis(object):
             dfactor = (lumdist * 1e5)**2 / (1 + self.params['zred'])
         if peraa:
             # spectrum will be in erg/s/cm^2/AA
-            smspec *= to_cgs / dfactor * lightspeed / outwave**2
+            smspec *= to_cgs / dfactor * lightspeed / wa**2
         else:
             # Spectrum will be in maggies
             smspec *= to_cgs / dfactor / 1e3 / (3631*jansky_mks)


### PR DESCRIPTION
The peraa keyword wasn't being properly passed from Sedmodel.sed() to sps.get_spectrum(). Not sure if this is the way you want to fix it (since now the peraa default is being set in Sedmodel.sed() as well), but this is one way to fix it.