### PR TITLE
Prior check

### DIFF
--- a/prospect/fitting/fitterutils.py
+++ b/prospect/fitting/fitterutils.py
@@ -146,7 +146,7 @@ def emcee_burn(sampler, initial_center, nburn, model=None, prob0=None,
         else:
             initial = reinitialize_ball_covar(epos, eprob, center=initial_center,
                                               limits=limits, disp_floor=disp_floor,
-                                              **kwargs)
+                                              prior_check=model, **kwargs)
         sampler.reset()
         if verbose:
             print('done burn #{}'.format(k))

--- a/prospect/sources/ssp_basis.py
+++ b/prospect/sources/ssp_basis.py
@@ -168,9 +168,11 @@ class SSPBasis(object):
         if 'zred' in self.reserved_params:
             # We do it ourselves.
             a = 1 + self.params.get('zred', 0)
+            af = a
             b = 0.0
         else:
             a, b = 1.0, 0.0
+            af = 1 + self.params.get('zred', 0)
 
         if 'wavecal_coeffs' in self.params:
             x = wave - wave.min()
@@ -179,13 +181,13 @@ class SSPBasis(object):
             # assume coeeficients give shifts in km/s
             b = chebval(x, c) / (lightspeed*1e-13)
             
-        wa, sa = wave * (a + b), spectrum * a
+        wa, sa = wave * (a + b), spectrum * af
         if outwave is None:
             outwave = wa
 
         # Observed frame photometry, as absolute maggies
         if filters is not None:
-            mags = getSED(wave, lightspeed/wave**2 * sa * to_cgs, filters)
+            mags = getSED(wa, lightspeed/wa**2 * sa * to_cgs, filters)
             phot = np.atleast_1d(10**(-0.4 * mags))
         else:
             phot = 0.0
@@ -211,7 +213,7 @@ class SSPBasis(object):
             dfactor = (self.params.get('lumdist', 1e-5) * 1e5)**2
         else:
             lumdist = cosmo.luminosity_distance(self.params['zred']).value
-            dfactor = (lumdist * 1e5)**2 / (1 + self.params['zred'])
+            dfactor = (lumdist * 1e5)**2 #/ (1 + self.params['zred'])
         if peraa:
             # spectrum will be in erg/s/cm^2/AA
             smspec *= to_cgs / dfactor * lightspeed / outwave**2


### PR DESCRIPTION
I've noticed some of the walkers were initialized outside the priors (in "stuck" positions) in the MCMC production run. The "stuck" walkers are specifically violating the linked priors. I read over fitterutils.py carefully and think that this is being caused by the function call in line 148, where the prior_check=model isn't being passed to reinitialize_ball_covar. I investigated whether passing prior_check=model fixes the walkers initialized outside the priors, and it worked for my test case.