### PR TITLE
add in linked prior check to reinitialize_ball_covar call

### DIFF
--- a/prospect/fitting/fitterutils.py
+++ b/prospect/fitting/fitterutils.py
@@ -146,7 +146,7 @@ def emcee_burn(sampler, initial_center, nburn, model=None, prob0=None,
         else:
             initial = reinitialize_ball_covar(epos, eprob, center=initial_center,
                                               limits=limits, disp_floor=disp_floor,
-                                              **kwargs)
+                                              prior_check=model, **kwargs)
         sampler.reset()
         if verbose:
             print('done burn #{}'.format(k))


### PR DESCRIPTION
I've noticed some of the walkers were initialized outside the priors (in "stuck" positions) in the MCMC production run. The "stuck" walkers are specifically violating the linked priors. I read over fitterutils.py carefully and think that this is being caused by the function call in line 148, where the prior_check=model isn't being passed to reinitialize_ball_covar. I investigated whether passing prior_check=model fixes the walkers initialized outside the priors, and it worked for my test case.

(removed redshift stuff from pull request)