### PR TITLE
Iterative hdf5

### DIFF
--- a/prospect/__init__.py
+++ b/prospect/__init__.py
@@ -1,3 +1,8 @@
+try:
+    from ._version import __version__
+except(ImportError):
+    pass
+
 from . import models
 from . import fitting
 from . import io

--- a/prospect/fitting/fitterutils.py
+++ b/prospect/fitting/fitterutils.py
@@ -74,9 +74,10 @@ def run_emcee_sampler(lnprobf, initial_center, model, verbose=True,
     # Production run
     esampler.reset()
     if hdf5 is not None:
-        # Set up output
-        chain = hdf5.create_dataset("chain", (nwalkers, niter, ndim))
-        lnpout = hdf5.create_dataset("lnprobability", (nwalkers, niter))
+        # Set up hdf5 backend
+        sdat = hdf5.create_group('sampling')
+        chain = sdat.create_dataset("chain", (nwalkers, niter, ndim))
+        lnpout = sdat.create_dataset("lnprobability", (nwalkers, niter))
         # blob = hdf5.create_dataset("blob")
         storechain = False
     else:
@@ -90,10 +91,11 @@ def run_emcee_sampler(lnprobf, initial_center, model, verbose=True,
         if hdf5 is not None:
             chain[:, i, :] = result[0]
             lnpout[:, i] = result[1]
-            if np.mod(i+1, int(interval*niter)) == 0:
+            if (np.mod(i+1, int(interval*niter)) == 0) or (i+1 == niter):
                 # do stuff every once in awhile
                 # this would be the place to put some callback functions
                 # e.g. [do(result, i, esampler) for do in things_to_do]
+                # like, should probably store the random state too.
                 hdf5.flush()
     if verbose:
         print('done production')

--- a/prospect/fitting/fitterutils.py
+++ b/prospect/fitting/fitterutils.py
@@ -196,8 +196,8 @@ def reinitialize_ball_covar(pos, prob, threshold=50.0, center=None,
         center = pos[good, :].mean(axis=0)
     Sigma = np.cov(pos[good, :].T)
     Sigma[np.diag_indices_from(Sigma)] += disp_floor**2
-    pnew = resample_until_valid(multivariate_normal, center, Sigma, nwalkers,
-                                **extras)
+    pnew = resample_until_valid(multivariate_normal, center, Sigma,
+                                nwalkers, **extras)
     return pnew
 
 
@@ -217,7 +217,8 @@ def reinitialize_ball(pos, prob, center=None, ptiles=[25, 50, 75],
     scatter = np.abs((tmp[2] - tmp[0]) / 1.35)
     scatter = np.sqrt(scatter**2 + disp_floor**2)
 
-    pnew = resample_until_valid(sampler_ball, initial_center, scatter, nwalkers)
+    pnew = resample_until_valid(sampler_ball, initial_center, scatter,
+                                nwalkers, **extras)
     return pnew
 
 

--- a/prospect/io/write_results.py
+++ b/prospect/io/write_results.py
@@ -124,7 +124,7 @@ def paramfile_string(param_file=None, **extras):
 
         
 def write_hdf5(hfile, run_params, model, obs, sampler, powell_results,
-               tsample=0.0, toptimize=0.0, sampling_initial_center=None,
+               tsample=0.0, toptimize=0.0, sampling_initial_center=[],
                **extras):
     """Write output and information to an HDF5 file object (or
     group).  

--- a/prospect/io/write_results.py
+++ b/prospect/io/write_results.py
@@ -32,16 +32,21 @@ def githash(nofork=False, **extras):
         fork, which can cause a problem on some MPI implementations (in a way
         that cannot be caught niceley)
     """
+    try:
+        from .._version import __version__
+        bgh = __version__
+    except(ImportError):
+        bgh = "Can't get version number."
+
+    if nofork:
+        return bgh
+
     cmd = 'cd {0}; git log --format="format:%h"'
-    if not nofork:
-        try:
-            bsfh_dir = os.path.dirname(__file__)
-            bgh = run_command(cmd.format(bsfh_dir))[1]
-        except:
-            print("Couldn't get Prospector git hash")
-            bgh = "Can't get hash for some reason"
-    else:
-        bgh = "Can't check hash (nofork=True)."
+    try:
+        bsfh_dir = os.path.dirname(__file__)
+        bgh = run_command(cmd.format(bsfh_dir))[1]
+    except:
+        print("Couldn't get Prospector history")
 
     return bgh
 

--- a/prospect/io/write_results.py
+++ b/prospect/io/write_results.py
@@ -7,7 +7,12 @@ try:
 except:
     pass
 
+
 __all__ = ["run_command", "githash", "write_pickles", "write_hdf5"]
+
+
+unserial = json.dumps('Unserializable')
+
 
 def run_command(cmd):
     """Open a child process, and return its exit status and stdout.
@@ -115,7 +120,7 @@ def paramfile_string(param_file=None, **extras):
         
 def write_hdf5(hfile, run_params, model, obs, sampler, powell_results,
                tsample=0.0, toptimize=0.0, sampling_initial_center=None,
-               mfile=None, **extras):
+               **extras):
     """Write output and information to an HDF5 file object (or
     group).  
     """
@@ -127,26 +132,6 @@ def write_hdf5(hfile, run_params, model, obs, sampler, powell_results,
     except(NameError):
         print("HDF5 file could not be opened, as h5py could not be imported.")
         return
-        
-    unserial = json.dumps('Unserializable')
-    # ----------------------
-    # High level parameter and version info
-    serialize = {'run_params': run_params,
-                 'model_params': [functions_to_names(p.copy()) for p in model.config_list],
-                 'paramfile_text': paramfile_string(**run_params)}
-    for k, v in list(serialize.items()):
-        try:
-            hf.attrs[k] = json.dumps(v) #, cls=NumpyEncoder)
-        except(TypeError):
-            # Should this fall back to pickle.dumps?
-            hf.attrs[k] = pickle.dumps(v)
-            print("Could not JSON serialize {}, pickled instead".format(k))
-        except:
-            hf.attrs[k] = unserial
-            print("Could not serialize {}".format(k))
-
-    hf.attrs['optimizer_duration'] = json.dumps(toptimize)
-    hf.flush()
 
     # ----------------------
     # Sampling info
@@ -166,8 +151,53 @@ def write_hdf5(hfile, run_params, model, obs, sampler, powell_results,
     hf.flush()
 
     # ----------------------
+    # High level parameter and version info
+    write_h5_header(hf, run_params, model)
+    hf.attrs['optimizer_duration'] = json.dumps(toptimize)
+    hf.flush()
+
+    # ----------------------
     # Observational data
-    odat = hf.create_group('obs')
+    write_obs_to_h5(hf, obs)
+    
+    # Store the githash last after flushing since getting it might cause an
+    # uncatchable crash
+    bgh = githash(**run_params)
+    hf.attrs['prospector_version'] = json.dumps(bgh)
+    hf.close()
+
+    #if mfile is None:
+    #    mfile = hf.name.replace('.h5', '_model')
+    #write_model_pickle(outroot + '_model', model, bgh=bgh, powell=powell_results)
+
+
+def write_h5_header(hf, run_params, model):
+    """Write header information about the run.
+    """
+    serialize = {'run_params': run_params,
+                 'model_params': [functions_to_names(p.copy()) for p in model.config_list],
+                 'paramfile_text': paramfile_string(**run_params)}
+    for k, v in list(serialize.items()):
+        try:
+            hf.attrs[k] = json.dumps(v) #, cls=NumpyEncoder)
+        except(TypeError):
+            # Should this fall back to pickle.dumps?
+            hf.attrs[k] = pickle.dumps(v)
+            print("Could not JSON serialize {}, pickled instead".format(k))
+        except:
+            hf.attrs[k] = unserial
+            print("Could not serialize {}".format(k))
+    hf.flush()
+
+
+def write_obs_to_h5(hf, obs):
+    """Write observational data to the hdf5 file
+    """
+    try:
+        odat = hf.create_group('obs')
+    except(ValueError):
+        # We already have an 'obs' group
+        return
     for k, v in list(obs.items()):
         if k == 'filters':
             try:
@@ -188,16 +218,8 @@ def write_hdf5(hfile, run_params, model, obs, sampler, powell_results,
                 print("Could not serialize {}".format(k))
 
     hf.flush()
-    # Store the githash last after flushing since getting it might cause an
-    # uncatchable crash
-    bgh = githash(**run_params)
-    hf.attrs['prospector_version'] = json.dumps(bgh)
-    hf.close()
 
-    #if mfile is None:
-    #    mfile = hf.name.replace('.h5', '_model')
-    #write_model_pickle(outroot + '_model', model, bgh=bgh, powell=powell_results)
-
+    
 class NumpyEncoder(json.JSONEncoder):
 
     def default(self, obj):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 import sys
 import re
 import glob
-
+import subprocess
 try:
     from setuptools import setup
     setup
@@ -13,10 +13,14 @@ except ImportError:
     from distutils.core import setup
     setup
 
+vers = subprocess.check_output(["git", "log", "--format=%h"]).split('\n')[0]
+with open('prospect/_version.py', "w") as f:
+    f.write('__version__ = "{}"'.format(vers))
+    
 setup(
     name="prospect",
     url="https://github.com/bd-j/prospect",
-    version='0.1.0',
+    version=vers,
     author="Ben Johnson",
     author_email="benjamin.johnson@cfa.harvard.edu",
     packages=["prospect",


### PR DESCRIPTION
This PR modifies the prospector.py script to write to an hdf5 file before and during sampling, so that intermediate results are saved in the case of a failure during sampling.  The interval for saving the chain is set by the `interval` keyword in the run_params dictionary, given in terms of the fraction of the full chain at which to flush to disk, and defaults to 1.0 (i.e. only flush at the end of the chain)

To make facilitate this the write_hdf5 method has been split into several pieces.

There is also now a hook in the setup.py script to set the __version__ variable to the prospector githash.