### PR TITLE
Faststep

### DIFF
--- a/demo/demo_mock_params.py
+++ b/demo/demo_mock_params.py
@@ -252,6 +252,10 @@ model_params.append({'name': 'agb_dust', 'N': 1,
 
 # --- Nebular Emission ------
 
+model_params.append({'name': 'add_neb_emission', 'N': 1,
+                        'isfree': False,
+                        'init': False})
+
 # Here is a really simple function that takes a **dict argument, picks out the
 # `logzsol` key, and returns the value.  This way, we can have gas_logz find
 # the value of logzsol and use it, if we uncomment the 'depends_on' line in the
@@ -261,6 +265,8 @@ model_params.append({'name': 'agb_dust', 'N': 1,
 # them linear instead of log, or divide everything by 10, or whatever.) You can
 # have one parameter depend on several others (or vice versa).  Just remember
 # that a parameter with `depends_on` must always be fixed.
+
+
 
 def stellar_logzsol(logzsol=0.0, **extras):
     return logzsol

--- a/demo/demo_params.py
+++ b/demo/demo_params.py
@@ -304,6 +304,11 @@ model_params.append({'name': 'agb_dust', 'N': 1,
 
 # --- Nebular Emission ------
 
+# FSPS parameter
+model_params.append({'name': 'add_neb_emission', 'N': 1,
+                     'isfree': False,
+                     'init': True})
+
 # Here is a really simple function that takes a **dict argument, picks out the
 # `logzsol` key, and returns the value.  This way, we can have gas_logz find
 # the value of logzsol and use it, if we uncomment the 'depends_on' line in the
@@ -317,12 +322,6 @@ model_params.append({'name': 'agb_dust', 'N': 1,
 def stellar_logzsol(logzsol=0.0, **extras):
     return logzsol
 
-
-# FSPS parameter
-model_params.append({'name': 'add_neb_emission', 'N': 1,
-                        'isfree': False,
-                        'init': True,
-                        'units': ''})
 
 # FSPS parameter
 model_params.append({'name': 'gas_logz', 'N': 1,

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -99,7 +99,7 @@ Data manipulation parameters:
 
 ``"rescale_spectrum"``
     Boolean.  If ``True``, rescale the spectrum to have an average of 1 before doing anything.
-    The scaling parameter is stored in the ``obs`` dict as ``obs["rescale"]``
+    The scaling parameter is stored in the ``obs`` dict as ``obs["rescale"]``.
 		This parameter should be ``False`` unless you are simultaneously fitting photometry
 		(see ``normalize_spectrum`` below),
 		or you are fitting for the spectral calibration as well.

--- a/prospect/sources/ssp_basis.py
+++ b/prospect/sources/ssp_basis.py
@@ -15,8 +15,9 @@ try:
 except(ImportError):
     pass
 
-__all__ = ["SSPBasis", "FastSSPBasis", "MultiSSPBasis",
-           "LinearSFHBasis", "StepSFHBasis", "CompositeSFH"]
+__all__ = ["SSPBasis", "FastSSPBasis", "FastStepBasis",
+           "MultiSSPBasis", "LinearSFHBasis",
+           "StepSFHBasis", "CompositeSFH"]
 
 
 # Useful constants
@@ -48,7 +49,7 @@ class SSPBasis(object):
 
     def __init__(self, compute_vega_mags=False, zcontinuous=1,
                  interp_type='logarithmic', flux_interp='linear', sfh_type='ssp',
-                 mint_log=-3, reserved_params=['sfh', 'tage', 'zred', 'sigma_smooth'],
+                 mint_log=-3, reserved_params=['tage', 'zred', 'sigma_smooth'],
                  **kwargs):
         """
         :param interp_type: (default: "logarithmic")
@@ -108,7 +109,8 @@ class SSPBasis(object):
                 self.ssp.params[k] = deepcopy(v)
 
         # We use FSPS for SSPs !!ONLY!!
-        assert self.ssp.params['sfh'] == 0
+        # except for FastStepBasis
+        #assert self.ssp.params['sfh'] == 0
 
     def get_galaxy_spectrum(self, **params):
         """Update parameters, then multiply SSP weights by SSP spectra and
@@ -285,33 +287,51 @@ class FastStepBasis(SSPBasis):
 
     def get_galaxy_spectrum(self, **params):
         self.update(**params)
-        time, sfr = self.convert_sfh(self.params['agebins'], self.params['mass'])
+        mtot = self.params['mass'].sum()
+        time, sfr, tmax = self.convert_sfh(self.params['agebins'], self.params['mass'])
+        self.ssp.params["sfh"] = 3 #Hack to avoid rewriting the superclass
         self.ssp.set_tabular_sfh(time, sfr)
         wave, spec = self.ssp.get_spectrum(tage=tmax, peraa=False)
-        return wave, spec, self.ssp.stellar_mass
+        return wave, spec / mtot, self.ssp.stellar_mass / mtot
 
-    def convert_sfh(self, agebins, mass, epsilon=0.0001, maxage=None):
+    def convert_sfh(self, agebins, mformed, epsilon=1e-4, maxage=None):
         """Given AGEBIN of shape (N, 2), MFORMED of shape (n,)  the time vector
         should be on EITHER SIDE of each bin edge with a "closeness" defined by
         a parameter epsilon.
 
-        :param epsilon: (default, 0.0001)
+        :param agebins:
+            An array of bin edges, log(yrs).  This method assumes that the upper edge of
+            one bin is the same as the lower edge of another bin.  ndarray of shape (N, 2)
+
+        :param mformed:
+            The stellar mass formed in each bin.  ndarray of shape (N,)
+
+        :param epsilon: (optional, default 1e-4)
             A small number used to define the fraction time separation of
             adjacent points at the bin edges.
+
+        :param maxage: (optional, default None)
+            A maximum age of stars in the population, in yrs.  If None then the maximum
+            value of agebins is used.  Note that an error will occur if maxage
+            < the maximum age in agebins.
 
         :returns time:
             The output time array for use with sfh=3, in Gyr.  ndarray of shape (2*N)
 
         :returns sfr:
             The output sfr array for use with sfh=3, in M_sun/yr.  ndarray of shape (2*N)
+
+        :returns maxage:
+            The maximum valid age in the returned isochrone.
         """
         #### create time vector
-        agebins_yrs = 10**agebins
+        agebins_yrs = 10**agebins.T
         dt = agebins_yrs[1, :] - agebins_yrs[0, :]
         bin_edges = np.unique(agebins_yrs)
-        if maxage is not None:
+        if maxage is None:
             maxage = agebins_yrs.max()  # can replace maxage with something else, e.g. tuniv
-        t = np.concatenate((bin_edges*(1.-epsilon), bin_edges*(1+epsilon))).sort()
+        t = np.concatenate((bin_edges*(1.-epsilon), bin_edges*(1+epsilon)))
+        t.sort()
         t = t[1:-1] # remove older than oldest bin, younger than youngest bin
         fsps_time = maxage - t
 
@@ -319,9 +339,9 @@ class FastStepBasis(SSPBasis):
         sfr = mformed / dt
         sfrout = np.zeros_like(t)
         sfrout[::2] = sfr
-        sfrout[1::2] = sfr
+        sfrout[1::2] = sfr #* (1+epsilon)
 
-        return fsps_time / 1e9, sfrout
+        return (fsps_time / 1e9)[::-1], sfrout[::-1], maxage / 1e9
 
 
 class MultiSSPBasis(SSPBasis):


### PR DESCRIPTION
This PR introduces a new source object (in ssp_basis.py) that offloads the step-function SFH (non-parameteric SF) calculations to the python-FSPS ``sfh=3`` mode.  Use of the new ``FastStepBasis`` in place of ``StepSFHBasis`` results in substantial speedups for photometric fitting, even when including nebular emission.

There are also minor doc and demo changes.