### PR TITLE
Getspec updates

### DIFF
--- a/prospect/likelihood/noise_model.py
+++ b/prospect/likelihood/noise_model.py
@@ -6,11 +6,13 @@ __all__ = ["NoiseModel"]
 
 class NoiseModel(object):
 
-    def __init__(self, metric_name='', kernels=[], weight_by=[]):
+    def __init__(self, metric_name='', mask_name='mask', kernels=[],
+                 weight_by=[]):
         assert len(kernels) == len(weight_by)
         self.kernels = kernels
         self.weight_names = weight_by
         self.metric_name = metric_name
+        self.mask_name = mask_name
 
     def update(self, **params):
         [k.update(**params) for k in self.kernels]
@@ -36,7 +38,7 @@ class NoiseModel(object):
         that correspond to each kernel, as stored in the `weight_names`
         attribute.  A None vector will result in None weights
         """
-        mask = vectors.get('mask', slice(None))
+        mask = vectors.get(self.mask_name, slice(None))
         wghts = []
         for w in self.weight_names:
             if vectors[w] is None:
@@ -45,7 +47,7 @@ class NoiseModel(object):
                 wghts.append(vectors[w][mask])
         return wghts
 
-    def compute(self, **vectors):
+    def compute(self, check_finite=False, **vectors):
         """Build and cache the covariance matrix, and if it is 2-d factorize it
         and cache that.  Also cache ``log_det``.
         """

--- a/prospect/sources/galaxy_basis.py
+++ b/prospect/sources/galaxy_basis.py
@@ -166,7 +166,8 @@ class CSPBasis(object):
             w = self.csp.wavelengths
             spec = np.interp(outwave, w, spec)
         # Distance dimming and unit conversion
-        if (self.params['zred'] == 0) or ('lumdist' in self.params):
+        zred = self.params.get('zred', 0.0)
+        if (zred == 0) or ('lumdist' in self.params):
             # Use 10pc for the luminosity distance (or a number provided in the
             # lumdist key in units of Mpc).  Do not apply cosmological (1+z)
             # factor to the flux.
@@ -175,7 +176,7 @@ class CSPBasis(object):
         else:
             # Use the comsological luminosity distance implied by this
             # redshift.  Cosmological (1+z) factor on the flux was already done in one_sed
-            lumdist = cosmo.luminosity_distance(self.params['zred']).value
+            lumdist = cosmo.luminosity_distance(zred).value
             dfactor = (lumdist * 1e5)**2
         if peraa:
             # spectrum will be in erg/s/cm^2/AA
@@ -228,7 +229,7 @@ class CSPBasis(object):
         w, spec = self.csp.get_spectrum(tage=self.csp.params['tage'], peraa=False)
         # redshift and get photometry.  Note we are boosting fnu by (1+z) *here*
         a, b = (1 + self.csp.params['zred']), 0.0
-        wa, sa = wave * (a + b), spectrum * a  # Observed Frame
+        wa, sa = w * (a + b), spec * a  # Observed Frame
         if filterlist is not None:
             mags = getSED(wa, lightspeed/wa**2 * sa * to_cgs, filterlist)
             phot = np.atleast_1d(10**(-0.4 * mags))

--- a/prospect/sources/galaxy_basis.py
+++ b/prospect/sources/galaxy_basis.py
@@ -221,11 +221,7 @@ class CSPBasis(object):
             except(IndexError, TypeError):
                 v = vs
             if k in self.csp.params.all_params:
-                if k == 'zmet':
-                    vv = np.abs(v - (np.arange(len(self.csp.zlegend)) + 1)).argmin() + 1
-                else:
-                    vv = v.copy()
-                self.csp.params[k] = vv
+                self.csp.params[k] = v.copy()
             if k == 'mass':
                 mass = v
         # Now get the magnitudes and spectrum.  The spectrum is in units of

--- a/prospect/sources/ssp_basis.py
+++ b/prospect/sources/ssp_basis.py
@@ -208,12 +208,13 @@ class SSPBasis(object):
             smspec = sa
 
         # Distance dimming and unit conversion
-        if (self.params['zred'] == 0) or ('lumdist' in self.params):
+        zred = self.params.get('zred', 0.0)
+        if (zred == 0) or ('lumdist' in self.params):
             # Use 10pc for the luminosity distance (or a number
             # provided in the dist key in units of Mpc)
             dfactor = (self.params.get('lumdist', 1e-5) * 1e5)**2
         else:
-            lumdist = cosmo.luminosity_distance(self.params['zred']).value
+            lumdist = cosmo.luminosity_distance(zred).value
             dfactor = (lumdist * 1e5)**2
         if peraa:
             # spectrum will be in erg/s/cm^2/AA

--- a/prospect/sources/ssp_basis.py
+++ b/prospect/sources/ssp_basis.py
@@ -49,7 +49,7 @@ class SSPBasis(object):
 
     def __init__(self, compute_vega_mags=False, zcontinuous=1,
                  interp_type='logarithmic', flux_interp='linear', sfh_type='ssp',
-                 mint_log=-3, reserved_params=['tage', 'zred', 'sigma_smooth'],
+                 mint_log=-3, reserved_params=['tage', 'sigma_smooth'],
                  **kwargs):
         """
         :param interp_type: (default: "logarithmic")
@@ -170,16 +170,10 @@ class SSPBasis(object):
         wave, spectrum, mfrac = self.get_galaxy_spectrum(**params)
 
         # Redshifting + Wavelength solution
-        if 'zred' in self.reserved_params:
-            # We do it ourselves.
-            a = 1 + self.params.get('zred', 0)
-            af = a
-            b = 0.0
-        else:
-            a, b = 1.0, 0.0
-            # FSPS shifts the wavelength vector but we need to decrease the
-            # flux by (1+z) here.
-            af = 1 + self.params.get('zred', 0)
+        # We do it ourselves.
+        a = 1 + self.params.get('zred', 0)
+        af = a
+        b = 0.0
 
         if 'wavecal_coeffs' in self.params:
             x = wave - wave.min()


### PR DESCRIPTION
FSPS now returns a restframe rather than redshifted spectrum when ``zred > 0`` (for good reasons, as of a few months ago).  This broke some parts of ``CSPBasis``, and made some parts of ``SSPBasis`` unnecessary. In particular, when ``zred > 0`` the photometry from parametric models was wrong.

This PR fixes ``CSPBasis`` and adds a little more flexibility for both ``CSPBasis`` and ``SSPBasis`` (``zred`` now not a required parameter, ``CSPBasis`` need not be given filters)
