### PR TITLE
fix outwave in CSPBasis when peraa=True

### DIFF
--- a/prospect/sources/galaxy_basis.py
+++ b/prospect/sources/galaxy_basis.py
@@ -165,6 +165,8 @@ class CSPBasis(object):
         if outwave is not None:
             w = self.csp.wavelengths
             spec = np.interp(outwave, w, spec)
+        else:
+            outwave = w
         # Distance dimming and unit conversion
         zred = self.params.get('zred', 0.0)
         if (zred == 0) or ('lumdist' in self.params):


### PR DESCRIPTION
when peraa is true and outwave=None, CSPBasis crashes. small fix.