### PR TITLE
Nested sampling

### DIFF
--- a/demo/demo_nestle_mock_params.py
+++ b/demo/demo_nestle_mock_params.py
@@ -1,0 +1,315 @@
+from copy import deepcopy
+import numpy as np
+from prospect.models import priors, sedmodel
+from prospect.sources import CSPBasis
+
+from sedpy.observate import load_filters
+
+tophat = None
+
+# --------------
+# RUN_PARAMS
+# --------------
+
+run_params = {'verbose':True,
+              'debug':False,
+              'outfile':'output/demo_nestle_mock',
+              # Fitter parameters
+              'nestle_npoints': 200,
+              'do_powell': True,
+              'ftol':0.5e-5, 'maxfev':5000,
+              'initial_disp':0.1,
+              # Mock data parameters
+              'snr': 20.0,
+              'add_noise': False,
+              # Mock model parameters
+              'mass': 1e7,
+              'logzsol': -0.5,
+              'tage': 12.,
+              'tau': 3.,
+              'dust2': 0.3,
+              # Data manipulation parameters
+              'logify_spectrum':False,
+              'normalize_spectrum':False,
+              # SPS parameters
+              'zcontinuous': 1,
+              }
+
+# --------------
+# OBS
+# --------------
+
+# Here we are going to put together some filter names
+# All these filters are available in sedpy.  If you want to use other filters,
+# add their transmission profiles to sedpy/sedpy/data/filters/ with appropriate
+# names (and format)
+galex = ['galex_FUV', 'galex_NUV']
+spitzer = ['spitzer_irac_ch'+n for n in ['1','2','3','4']]
+sdss = ['sdss_{0}0'.format(b) for b in ['u','g','r','i','z']]
+
+
+def load_obs(snr=10.0, add_noise=True, **kwargs):
+    """Make a mock dataset.  Feel free to add more complicated kwargs, and put
+    other things in the run_params dictionary to control how the mock is
+    generated.
+    """
+    # We'll put the mock data in this dictionary, just as we would for real
+    # data.  But we need to know which filters (and wavelengths if doing
+    # spectroscopy) with which to generate mock data.
+    mock = {}
+    mock['wavelength'] = None # No spectrum
+    filterset = galex + sdss + spitzer[:2] # only warm spitzer
+    mock['filters'] = load_filters(filterset)
+
+    # We need the models to make a mock
+    sps = load_sps(**kwargs)
+    mod = load_model(**kwargs)
+
+    # Now we get the mock params from the kwargs dict
+    params = {}
+    for p in mod.params.keys():
+        if p in kwargs:
+            params[p] = np.atleast_1d(kwargs[p])
+
+    # And build the mock
+    mod.params.update(params)
+    spec, phot, _ = mod.mean_model(mod.theta, mock, sps=sps)
+    # Now store some output
+    mock['true_spectrum'] = spec.copy()
+    mock['true_maggies'] = phot.copy()
+    mock['mock_params'] = deepcopy(mod.params)
+    # And add noise
+    pnoise_sigma = phot / snr
+    pnoise = np.random.normal(0, 1, len(phot)) * pnoise_sigma
+    if add_noise:
+        mock['maggies'] = phot + pnoise
+    else:
+        mock['maggies'] = phot.copy()
+    mock['maggies_unc'] = pnoise_sigma
+    mock['mock_snr'] = snr
+    mock['phot_mask'] = np.ones(len(phot), dtype=bool)
+
+    return mock
+
+# --------------
+# SPS Object
+# --------------
+
+def load_sps(zcontinuous=1, compute_vega_mags=False, **extras):
+    sps = CSPBasis(zcontinuous=zcontinuous,
+                   compute_vega_mags=compute_vega_mags)
+    return sps
+
+# -----------------
+# Gaussian Process
+# ------------------
+
+def load_gp(**extras):
+    return None, None
+
+# --------------
+# MODEL_PARAMS
+# --------------
+
+# You'll note below that we have 5 free parameters:
+# mass, logzsol, tage, tau, dust2
+# Each has tophat priors. They are all scalars.
+#
+# The other parameters are all fixed, but we want to explicitly set their
+# values.
+
+model_params = []
+
+# --- Distance ---
+model_params.append({'name': 'zred', 'N': 1,
+                        'isfree': False,
+                        'init': 0.0,
+                        'units': '',
+                        'prior': priors.TopHat(mini=0.0, maxi=4.0)})
+
+# --- SFH --------
+model_params.append({'name': 'sfh', 'N': 1,
+                        'isfree': False,
+                        'init': 4,
+                        'units': 'type',
+                        'prior': None})
+
+model_params.append({'name': 'mass', 'N': 1,
+                        'isfree': True,
+                        'init': 1e7,
+                        'init_disp': 1e6,
+                        'units': r'M_\odot',
+                        'prior': priors.TopHat(mini=1e6, maxi=1e9)})
+
+model_params.append({'name': 'logzsol', 'N': 1,
+                        'isfree': True,
+                        'init': -0.3,
+                        'init_disp': 0.3,
+                        'units': r'$\log (Z/Z_\odot)$',
+                        'prior': priors.TopHat(mini=-1, maxi=0.19)})
+
+# If zcontinuous > 1, use 3-pt smoothing
+model_params.append({'name': 'pmetals', 'N': 1,
+                        'isfree': False,
+                        'init': -99,
+                        'prior': None})
+                        
+model_params.append({'name': 'tau', 'N': 1,
+                        'isfree': True,
+                        'init': 1.0,
+                        'init_disp': 0.5,
+                        'units': 'Gyr',
+                        'prior':priors.TopHat(mini=0.1, maxi=100)})
+
+model_params.append({'name': 'tage', 'N': 1,
+                        'isfree': True,
+                        'init': 5.0,
+                        'init_disp': 3.0,
+                        'units': 'Gyr',
+                        'prior': priors.TopHat(mini=0.101, maxi=14.0)})
+
+model_params.append({'name': 'sfstart', 'N': 1,
+                        'isfree': False,
+                        'init': 0.0,
+                        'units': 'Gyr',
+                        'prior': None})
+
+model_params.append({'name': 'fage_burst', 'N': 1,
+                        'isfree': False,
+                        'init': 0.0,
+                        'units': '',
+                        'prior': priors.TopHat(mini=0.9, maxi=1.0)})
+
+def tburst_fage(tage=0.0, fage_burst=0.0, **extras):
+    return tage * fage_burst
+
+model_params.append({'name': 'tburst', 'N': 1,
+                        'isfree': False,
+                        'init': 0.0,
+                        'units': '',
+                        'prior': None,})
+                        #'depends_on': tburst_fage})
+
+model_params.append({'name': 'fburst', 'N': 1,
+                        'isfree': False,
+                        'init': 0.0,
+                        'units': '',
+                        'prior': priors.TopHat(mini=0.0, maxi=0.5)})
+
+# --- Dust ---------
+model_params.append({'name': 'dust1', 'N': 1,
+                        'isfree': False,
+                        'init': 0.0,
+                        'units': '',
+                        'prior': None,})
+
+model_params.append({'name': 'dust2', 'N': 1,
+                        'isfree': True,
+                        'init': 0.35,
+                        'reinit': True,
+                        'init_disp': 0.3,
+                        'units': '',
+                        'prior': priors.TopHat(mini=0.0, maxi=2.0)})
+
+model_params.append({'name': 'dust_index', 'N': 1,
+                        'isfree': False,
+                        'init': -0.7,
+                        'units': '',
+                        'prior': None,})
+
+model_params.append({'name': 'dust1_index', 'N': 1,
+                        'isfree': False,
+                        'init': -1.0,
+                        'units': '',
+                        'prior': None,})
+
+model_params.append({'name': 'dust_tesc', 'N': 1,
+                        'isfree': False,
+                        'init': 7.0,
+                        'units': 'log(Gyr)',
+                        'prior': None,})
+
+model_params.append({'name': 'dust_type', 'N': 1,
+                        'isfree': False,
+                        'init': 0,
+                        'units': 'index',
+                        'prior': None})
+
+model_params.append({'name': 'add_dust_emission', 'N': 1,
+                        'isfree': False,
+                        'init': True,
+                        'units': 'index',
+                        'prior': None})
+
+model_params.append({'name': 'duste_umin', 'N': 1,
+                        'isfree': False,
+                        'init': 1.0,
+                        'units': 'MMP83 local MW intensity',
+                        'prior': None})
+
+# --- Stellar Pops ------------
+model_params.append({'name': 'tpagb_norm_type', 'N': 1,
+                        'isfree': False,
+                        'init': 2,
+                        'units': 'index',
+                        'prior': None})
+
+model_params.append({'name': 'add_agb_dust_model', 'N': 1,
+                        'isfree': False,
+                        'init': True,
+                        'units': 'index',
+                        'prior': None})
+
+model_params.append({'name': 'agb_dust', 'N': 1,
+                        'isfree': False,
+                        'init': 1,
+                        'units': 'index',
+                        'prior': None})
+
+# --- Nebular Emission ------
+
+# For speed we turn off nebular emission in the demo
+model_params.append({'name': 'add_neb_emission', 'N': 1,
+                        'isfree': False,
+                        'init': False,
+                        'prior': None})
+
+# Here is a really simple function that takes a **dict argument, picks out the
+# `logzsol` key, and returns the value.  This way, we can have gas_logz find
+# the value of logzsol and use it, if we uncomment the 'depends_on' line in the
+# `gas_logz` parameter definition.
+#
+# One can use this kind of thing to transform parameters as well (like making
+# them linear instead of log, or divide everything by 10, or whatever.) You can
+# have one parameter depend on several others (or vice versa).  Just remember
+# that a parameter with `depends_on` must always be fixed.
+
+def stellar_logzsol(logzsol=0.0, **extras):
+    return logzsol
+
+model_params.append({'name': 'gas_logz', 'N': 1,
+                        'isfree': False,
+                        'init': 0.0,
+                        'units': r'log Z/Z_\odot',
+#                        'depends_on': stellar_logzsol,
+                        'prior': priors.TopHat(mini=-2.0, maxi=0.5)})
+
+model_params.append({'name': 'gas_logu', 'N': 1,
+                        'isfree': False,
+                        'init': -2.0,
+                        'units': '',
+                        'prior': priors.TopHat(mini=-4, maxi=-1)})
+
+# --- Calibration ---------
+model_params.append({'name': 'phot_jitter', 'N': 1,
+                        'isfree': False,
+                        'init': 0.0,
+                        'units': 'mags',
+                        'prior': priors.TopHat(mini=0.0, maxi=0.2)})
+
+def load_model(**extras):
+    # In principle (and we've done it) you could have the model depend on
+    # command line arguments (or anything in run_params) by making changes to
+    # `model_params` here before instantiation the SedModel object.  Up to you.
+    return sedmodel.SedModel(model_params)
+

--- a/prospect/fitting/__init__.py
+++ b/prospect/fitting/__init__.py
@@ -1,4 +1,7 @@
-from .fitterutils import *
+from .ensemble import *
+from .minimizer import *
+from .nested import *
 
 __all__ = ["run_emcee_sampler", "reinitialize_ball", "sampler_ball",
+           "run_nested_sampler",
            "pminimize", "minimizer_ball", "reinitialize"]

--- a/prospect/fitting/ensemble.py
+++ b/prospect/fitting/ensemble.py
@@ -2,7 +2,10 @@ import sys
 import numpy as np
 from numpy.random import normal, multivariate_normal
 
-import emcee
+try:
+    import emcee
+except(ImportError):
+    pass
 
 from ..models.priors import plotting_range
 

--- a/prospect/fitting/ensemble.py
+++ b/prospect/fitting/ensemble.py
@@ -1,12 +1,14 @@
 import sys
 import numpy as np
 from numpy.random import normal, multivariate_normal
+
 import emcee
-from . import minimizer
+
 from ..models.priors import plotting_range
 
-__all__ = ["run_emcee_sampler", "reinitialize_ball", "sampler_ball", "emcee_burn",
-           "pminimize", "minimizer_ball", "reinitialize"]
+
+__all__ = ["run_emcee_sampler", "reinitialize_ball", "sampler_ball",
+           "emcee_burn"]
 
 
 def run_emcee_sampler(lnprobf, initial_center, model, verbose=True,
@@ -331,90 +333,6 @@ def restart_sampler(sample_results, lnprobf, sps, niter,
                                      threads=nthreads,  pool=pool)
     epos, eprob, state = esampler.run_mcmc(initial, niter, rstate0=state)
     return esampler
-
-
-def pminimize(chi2fn, initial, args=None, model=None,
-              method='powell', opts=None,
-              pool=None, nthreads=1):
-    """Do as many minimizations as you have threads, in parallel.  Always use
-    initial_center for one of the minimization streams, the rest will be
-    sampled from the prior for each parameter.  Returns each of the
-    minimization result dictionaries, as well as the starting positions.
-    """
-    # Instantiate the minimizer
-    mini = minimizer.Pminimize(chi2fn, args, opts,
-                               method=method, pool=pool, nthreads=1)
-    size = mini.size
-    pinitial = minimizer_ball(initial, size, model)
-    powell_guesses = mini.run(pinitial)
-
-    return [powell_guesses, pinitial]
-
-
-def reinitialize(best_guess, model, edge_trunc=0.1, reinit_params=[],
-                 **extras):
-    """Check if the Powell minimization found a minimum close to the edge of
-    the prior for any parameter. If so, reinitialize to the center of the
-    prior.
-
-    This is only done for parameters where ``'reinit':True`` in the model
-    configuration dictionary, or for parameters in the supplied
-    ``reinit_params`` list.
-
-    :param buest_guess:
-        The result of some sort of optimization step, iterable of length
-        model.ndim.
-
-    :param model:
-        A ..models.parameters.ProspectorParams() object.
-
-    :param edge_trunc: (optional, default 0.1)
-        The fractional distance from the edge of the priors that triggers
-        reinitialization.
-
-    :param reinit_params: optional
-        A list of model parameter names to reinitialize, overrides the value or
-        presence of the ``reinit`` key in the model configuration dictionary.
-
-    :returns output:
-        The best_guess with parameters near the edge reset to be at the center
-        of the prior.  ndarray of shape (ndim,)
-    """
-    edge = edge_trunc
-    bounds = model.theta_bounds()
-    output = np.array(best_guess)
-    reinit = np.zeros(model.ndim, dtype=bool)
-    for p, inds in list(model.theta_index.items()):
-        reinit[inds[0]:inds[1]] = (model._config_dict[p].get('reinit', False) or
-                                   (p in reinit_params))
-
-    for k, (guess, bound) in enumerate(zip(best_guess, bounds)):
-        # Normalize the guess and the bounds
-        prange = bound[1] - bound[0]
-        g, b = guess/prange, bound/prange
-        if ((g - b[0] < edge) or (b[1] - g < edge)) and (reinit[k]):
-            output[k] = b[0] + prange/2
-    return output
-
-
-def minimizer_ball(center, nminimizers, model):
-    """Setup a 'grid' of parameter values uniformly distributed between min and
-    max More generally, this should sample from the prior for each parameter.
-    """
-    size = nminimizers
-    pinitial = [center]
-    if size > 1:
-        ginitial = np.zeros([size - 1, model.ndim])
-        for p, v in list(model.theta_index.items()):
-            start, stop = v
-            lo, hi = plotting_range(model._config_dict[p]['prior_args'])
-            if model._config_dict[p]['N'] > 1:
-                ginitial[:, start:stop] = np.array([np.random.uniform(l, h, size - 1)
-                                                    for l, h in zip(lo, hi)]).T
-            else:
-                ginitial[:, start] = np.random.uniform(lo, hi, size - 1)
-        pinitial += ginitial.tolist()
-    return pinitial
 
 
 def run_hmc_sampler(model, sps, lnprobf, initial_center, rp, pool=None):

--- a/prospect/fitting/minimizer.py
+++ b/prospect/fitting/minimizer.py
@@ -172,8 +172,8 @@ def reinitialize(best_guess, model, edge_trunc=0.1, reinit_params=[],
     output = np.array(best_guess)
     reinit = np.zeros(model.ndim, dtype=bool)
     for p, inds in list(model.theta_index.items()):
-        reinit[inds[0]:inds[1]] = (model._config_dict[p].get('reinit', False) or
-                                   (p in reinit_params))
+        reinit[inds] = (model._config_dict[p].get('reinit', False) or
+                        (p in reinit_params))
 
     for k, (guess, bound) in enumerate(zip(best_guess, bounds)):
         # Normalize the guess and the bounds

--- a/prospect/fitting/minimizer.py
+++ b/prospect/fitting/minimizer.py
@@ -1,9 +1,17 @@
 import numpy as np
+from numpy.random import normal, multivariate_normal
 from scipy.optimize import minimize
+
+from ..models.priors import plotting_range
+
 try:
     import multiprocessing
 except ImportError:
     pass
+
+
+__all__ = ["Pminimize", "pminimize", "minimizer_ball", "reinitialize"]
+
 
 class Pminimize(object):
     """
@@ -110,3 +118,83 @@ class _minimize_wrapper(object):
             print("  exception:")
             traceback.print_exc()
             raise
+
+
+def pminimize(chi2fn, initial, args=None, model=None,
+              method='powell', opts=None,
+              pool=None, nthreads=1):
+    """Do as many minimizations as you have threads, in parallel.  Always use
+    initial_center for one of the minimization streams, the rest will be
+    sampled from the prior for each parameter.  Returns each of the
+    minimization result dictionaries, as well as the starting positions.
+    """
+    # Instantiate the minimizer
+    mini = Pminimize(chi2fn, args, opts,
+                     method=method, pool=pool, nthreads=1)
+    size = mini.size
+    pinitial = minimizer_ball(initial, size, model)
+    powell_guesses = mini.run(pinitial)
+
+    return [powell_guesses, pinitial]
+
+
+def reinitialize(best_guess, model, edge_trunc=0.1, reinit_params=[],
+                 **extras):
+    """Check if the Powell minimization found a minimum close to the edge of
+    the prior for any parameter. If so, reinitialize to the center of the
+    prior.
+
+    This is only done for parameters where ``'reinit':True`` in the model
+    configuration dictionary, or for parameters in the supplied
+    ``reinit_params`` list.
+
+    :param buest_guess:
+        The result of some sort of optimization step, iterable of length
+        model.ndim.
+
+    :param model:
+        A ..models.parameters.ProspectorParams() object.
+
+    :param edge_trunc: (optional, default 0.1)
+        The fractional distance from the edge of the priors that triggers
+        reinitialization.
+
+    :param reinit_params: optional
+        A list of model parameter names to reinitialize, overrides the value or
+        presence of the ``reinit`` key in the model configuration dictionary.
+
+    :returns output:
+        The best_guess with parameters near the edge reset to be at the center
+        of the prior.  ndarray of shape (ndim,)
+    """
+    edge = edge_trunc
+    bounds = model.theta_bounds()
+    output = np.array(best_guess)
+    reinit = np.zeros(model.ndim, dtype=bool)
+    for p, inds in list(model.theta_index.items()):
+        reinit[inds[0]:inds[1]] = (model._config_dict[p].get('reinit', False) or
+                                   (p in reinit_params))
+
+    for k, (guess, bound) in enumerate(zip(best_guess, bounds)):
+        # Normalize the guess and the bounds
+        prange = bound[1] - bound[0]
+        g, b = guess/prange, bound/prange
+        if ((g - b[0] < edge) or (b[1] - g < edge)) and (reinit[k]):
+            output[k] = b[0] + prange/2
+    return output
+
+
+def minimizer_ball(center, nminimizers, model):
+    """Setup a 'grid' of parameter values uniformly distributed between min and
+    max More generally, this should sample from the prior for each parameter.
+    """
+    size = nminimizers
+    pinitial = [center]
+    if size > 1:
+        ginitial = np.zeros([size - 1, model.ndim])
+        for p, inds in list(model.theta_index.items()):
+            lo, hi = plotting_range(model._config_dict[p]['prior_args'])
+            ginitial[:, inds] = np.array([np.random.uniform(l, h, size - 1)
+                                          for l, h in zip(lo, hi)]).T
+        pinitial += ginitial.tolist()
+    return pinitial

--- a/prospect/fitting/nested.py
+++ b/prospect/fitting/nested.py
@@ -1,0 +1,19 @@
+import sys
+import numpy as np
+from numpy.random import normal, multivariate_normal
+
+try:
+    import nestle
+except(ImportError):
+    pass
+
+__all__ = ["run_nestle_sampler"]
+
+def run_nestle_sampler(lnprobf, model, verbose=True, callback=None,
+                       nestle_method='single', nestle_npoints=200,
+                       **kwargs):
+
+
+    result = nestle.sample(lnpostfn, model.prior_transform, model.ndim,
+                           method=nestle_method, npoints=nestle_npoints)
+    return result

--- a/prospect/fitting/nested.py
+++ b/prospect/fitting/nested.py
@@ -9,11 +9,12 @@ except(ImportError):
 
 __all__ = ["run_nestle_sampler"]
 
-def run_nestle_sampler(lnprobf, model, verbose=True, callback=None,
+def run_nestle_sampler(lnprobfn, model, verbose=True, callback=None,
                        nestle_method='single', nestle_npoints=200,
                        **kwargs):
 
 
-    result = nestle.sample(lnpostfn, model.prior_transform, model.ndim,
-                           method=nestle_method, npoints=nestle_npoints)
+    result = nestle.sample(lnprobfn, model.prior_transform, model.ndim,
+                           method=nestle_method, npoints=nestle_npoints,
+                           callback=nestle.print_progress, maxcall=int(1e6))
     return result

--- a/prospect/models/parameters.py
+++ b/prospect/models/parameters.py
@@ -120,14 +120,6 @@ class ProspectorParams(object):
             lnp_prior += this_prior
         return lnp_prior
 
-    def rescale_parameter(self, par, func):
-        """Superceded by the ``depends_on`` pattern.
-        """
-        ind = [p['name'] for p in self.config_list].index(par)
-        self.config_list[ind]['init'] = func(self.config_list[ind]['init'])
-        for k, v in list(self.config_list[ind]['prior_args'].items()):
-            self.config_list[ind]['prior_args'][k] = func(v)
-
     def propagate_parameter_dependencies(self):
         """Propogate any parameter dependecies. That is, for parameters whose
         value depends on another parameter, calculate those values and store

--- a/prospect/models/parameters.py
+++ b/prospect/models/parameters.py
@@ -120,7 +120,7 @@ class ProspectorParams(object):
         for k, inds in list(self.theta_index.items()):
             func = self._config_dict[k]['prior']
             kwargs = self._config_dict[k].get('prior_args', {})
-            this_prior = np.sum(func(theta_inds[inds], **kwargs))
+            this_prior = np.sum(func(theta[inds], **kwargs))
 
             if (not np.isfinite(this_prior)):
                 print('WARNING: ' + k + ' is out of bounds')
@@ -226,7 +226,7 @@ class ProspectorParams(object):
                 pb = self._config_dict[p]['prior'].bounds(**kwargs)
             except(AttributeError):
                 # old style
-                priors.plotting_range(self._config_dict[p].get('prior_args', {}))
+                pb = priors.plotting_range(self._config_dict[p]['prior_args'])
             bounds[inds, :] = np.array(pb).T
         # Force types ?
         bounds = [(np.atleast_1d(a)[0], np.atleast_1d(b)[0]) for a, b in bounds]

--- a/prospect/models/priors.py
+++ b/prospect/models/priors.py
@@ -83,7 +83,7 @@ def plotting_range(prior_args):
 
 class Prior(object):
     """Encapsulate the priors in an object.  Each prior should have a
-    distrinution name and optional parameters specifying scale and location
+    distribution name and optional parameters specifying scale and location
     (e.g. min/max or mean/sigma).  These can be aliased. When called, the
     argument should be a variable and it should return the ln-prior-probability
     of that value.
@@ -182,8 +182,9 @@ class TopHat(Prior):
     def range(self):
         return (self.params['mini'], self.params['maxi'])
 
-    @property
-    def bounds(self):
+    def bounds(self, **kwargs):
+        if len(kwargs) > 0:
+            self.update(**kwargs)
         return self.range
 
 
@@ -206,17 +207,7 @@ class Normal(Prior):
         return (self.params['mean'] - nsig * self.params['sigma'],
                 self.params['mean'] + self.params['sigma'])
 
-    @property
-    def bounds(self):
-        return None
-
-
-def prior_trans(self, unit_coords):
-    """Go from unit cube to parameter space.  Demo function.
-    """	
-    theta = np.zeros(len(unit_coords))
-    for k, inds in list(self.theta_index.items()):
-        func = self._config_dict[k]['prior'].unit_transform
-        # kwargs = self._config_dict[k]['prior_args']
-        theta[inds] = func(unit_coords[inds]) #, **kwargs)
-    return theta
+    def bounds(self, **kwargs):
+        #if len(kwargs) > 0:
+        #    self.update(**kwargs)
+        return (-np.inf, np.inf)

--- a/prospect/models/priors.py
+++ b/prospect/models/priors.py
@@ -180,19 +180,43 @@ class TopHat(Prior):
 
     @property
     def range(self):
-        return(self.params['mini'], self.params['maxi'])
+        return (self.params['mini'], self.params['maxi'])
 
     @property
     def bounds(self):
         return self.range
 
 
+class Normal(Prior):
+
+    prior_params = ['mean', 'sigma']
+    distribution = scipy.stats.norm
+
+    @property
+    def scale(self):
+        return self.params['sigma']
+
+    @property
+    def loc(self):
+        return self.params['mean']
+
+    @property
+    def range(self):
+        nsig = 4
+        return (self.params['mean'] - nsig * self.params['sigma'],
+                self.params['mean'] + self.params['sigma'])
+
+    @property
+    def bounds(self):
+        return None
+
+
 def prior_trans(self, unit_coords):
     """Go from unit cube to parameter space.  Demo function.
     """	
     theta = np.zeros(len(unit_coords))
-    for k, sel in list(self.theta_index.items()):
+    for k, inds in list(self.theta_index.items()):
         func = self._config_dict[k]['prior'].unit_transform
         # kwargs = self._config_dict[k]['prior_args']
-        theta[sel] = func(unit_coords[sel]) #, **kwargs)
+        theta[inds] = func(unit_coords[inds]) #, **kwargs)
     return theta

--- a/prospect/models/priors.py
+++ b/prospect/models/priors.py
@@ -1,29 +1,19 @@
-# Module containg various functions to be used as priors
+# Module containg various functions (or objects) to be used as priors.
+# These return the ln-prior-probability
 import numpy as np
 import scipy.stats
 
-__all__ = ["normal", "tophat", "normal_clipped", "positive",
-           "lognormal", "logarithmic",
-           "plotting_range"]
+__all__ = ["normal", "tophat", "normal_clipped", "lognormal", "logarithmic",
+           "plotting_range",
+           "Prior", "TopHat", "Normal"]
 
 
 def zeros(theta, **extras):
     return np.zeros_like(theta)
 
 
-def positive(theta, **extras):
-    """
-    Require that a parameter be positive.
-    """
-    p = 1.0 * np.zeros_like(theta)
-    n = theta < 0
-    p[n] = -np.infty
-    return p
-
-
 def tophat(theta, mini=0.0, maxi=1.0, **extras):
-    """
-    A simple tophat function.  Input can be scalar or matched vectors
+    """A simple tophat function.  Input can be scalar or matched vectors
     """
     lnp = 1.0 * np.zeros_like(theta)
     n = (theta < mini) | (theta > maxi)
@@ -32,15 +22,13 @@ def tophat(theta, mini=0.0, maxi=1.0, **extras):
 
 
 def normal(theta, mean=0.0, sigma=1.0, **extras):
-    """
-    A simple gaussian.  should make sure it can be vectorized.
+    """A simple gaussian.  should make sure it can be vectorized.
     """
     return np.log((2*np.pi)**(-0.5)/sigma) - (theta - mean)**2/(2*sigma**2)
 
 
 def normal_clipped(theta, mean=0.0, sigma=1.0, mini=0.0, maxi=1.0, **extras):
-    """
-    A clipped gaussian.
+    """A clipped gaussian.
     """
     lnp = np.log((2*np.pi)**(-0.5)/sigma) - (theta - mean)**2/(2*sigma**2)
     n = (theta < mini) | (theta > maxi)
@@ -50,8 +38,7 @@ def normal_clipped(theta, mean=0.0, sigma=1.0, mini=0.0, maxi=1.0, **extras):
 
 
 def lognormal(theta, log_mean=0.0, sigma=1.0, **extras):
-    """
-    A lognormal  gaussian.  should make sure it can be vectorized.
+    """A lognormal  gaussian.  should make sure it can be vectorized.
     """
     if np.all(theta > 0):
         return ( np.log((2*np.pi)**(-0.5)/(theta*sigma)) -
@@ -95,11 +82,12 @@ class Prior(object):
     """
 
     def __init__(self, parnames=[], name='', **kwargs):
-        """
+        """Constructor.
+
         :param parnames:
-            A list of names of the parameters params, used to alias the intrinsic
+            A list of names of the parameters, used to alias the intrinsic
             parameter names.  This way different instances of the same Prior
-            can (must) have different parameter names.
+            can have different parameter names, in case they are being fit for....
         """
         if len(parnames) == 0:
             parnames = self.prior_params
@@ -111,7 +99,7 @@ class Prior(object):
         self.update(**kwargs)
 
     def update(self, **kwargs):
-        """
+        """Update `params` values using alias.
         """
         for k in self.prior_params:
             try:

--- a/prospect/models/priors.py
+++ b/prospect/models/priors.py
@@ -1,5 +1,6 @@
 # Module containg various functions to be used as priors
 import numpy as np
+import scipy.stats
 
 __all__ = ["normal", "tophat", "normal_clipped", "positive",
            "lognormal", "logarithmic",

--- a/scripts/prospector_nest.py
+++ b/scripts/prospector_nest.py
@@ -1,0 +1,115 @@
+import time, sys, os
+import numpy as np
+np.errstate(invalid='ignore')
+
+from prospect.models import model_setup
+from prospect.io import write_results
+from prospect import fitting
+from prospect.likelihood import lnlike_spec, lnlike_phot, write_log
+
+
+# --------------
+# Read command line arguments
+# --------------
+sargv = sys.argv
+argdict = {'param_file': ''}
+clargs = model_setup.parse_args(sargv, argdict=argdict)
+run_params = model_setup.get_run_params(argv=sargv, **clargs)
+
+# --------------
+# Globals
+# --------------
+# SPS Model instance as global
+sps = model_setup.load_sps(**run_params)
+# GP instances as global
+spec_noise, phot_noise = model_setup.load_gp(**run_params)
+# Model as global
+global_model = model_setup.load_model(**run_params)
+# Obs as global
+global_obs = model_setup.load_obs(**run_params)
+
+# -----------------
+# LnP function as global
+# ------------------
+
+def lnprobfn(theta, model=None, obs=None, verbose=run_params['verbose']):
+    """Given a parameter vector and optionally a dictionary of observational
+    ata and a model object, return the ln of the posterior. This requires that
+    an sps object (and if using spectra and gaussian processes, a GP object) be
+    instantiated.
+
+    :param theta:
+        Input parameter vector, ndarray of shape (ndim,)
+
+    :param model:
+        bsfh.sedmodel model object, with attributes including ``params``, a
+        dictionary of model parameters.  It must also have ``prior_product()``,
+        and ``mean_model()`` methods defined.
+
+    :param obs:
+        A dictionary of observational data.  The keys should be
+          *``wavelength``
+          *``spectrum``
+          *``unc``
+          *``maggies``
+          *``maggies_unc``
+          *``filters``
+          * and optional spectroscopic ``mask`` and ``phot_mask``.
+
+    :returns lnp:
+        Ln posterior probability.
+    """
+    if model is None:
+        model = global_model
+    if obs is None:
+        obs = global_obs
+
+    lnp_prior = model.prior_product(theta)
+    if np.isfinite(lnp_prior):
+        # Generate mean model
+        t1 = time.time()
+        try:
+            mu, phot, x = model.mean_model(theta, obs, sps=sps)
+        except(ValueError):
+            return -np.infty
+        d1 = time.time() - t1
+
+        # Noise modeling
+        if spec_noise is not None:
+            spec_noise.update(**model.params)
+        if phot_noise is not None:
+            phot_noise.update(**model.params)
+        vectors = {'spec': mu, 'unc': obs['unc'],
+                   'sed': model._spec, 'cal': model._speccal,
+                   'phot': phot, 'maggies_unc': obs['maggies_unc']}
+
+        # Calculate likelihoods
+        t2 = time.time()
+        lnp_spec = lnlike_spec(mu, obs=obs, spec_noise=spec_noise, **vectors)
+        lnp_phot = lnlike_phot(phot, obs=obs, phot_noise=phot_noise, **vectors)
+        d2 = time.time() - t2
+        if verbose:
+            write_log(theta, lnp_prior, lnp_spec, lnp_phot, d1, d2)
+
+        return lnp_prior + lnp_phot + lnp_spec
+    else:
+        return -np.infty
+
+if __name__ == "__main__":
+
+    rp = run_params
+    rp['sys.argv'] = sys.argv
+    # Use the globals
+    model = global_model
+    obsdat = global_obs
+
+    # -------
+    # Sample
+    # -------
+    if rp['verbose']:
+        print('nestle sampling...')
+    tstart = time.time()
+    out = fitting.run_nestle_sampler(lnprobfn, model, **rp)
+    dur = time.time() - tstart
+    if rp['verbose']:
+        print('done emcee in {0}s'.format(dur))


### PR DESCRIPTION
This implements priors as objects (#17) for use with nested sampling (#67) which requires the https://github.com/kbarbary/nestle package.

Also the `theta_index` dictionary now returns slice objects instead of start/stop tuples.  This is important if you were using `theta_index` when implementing custom joint prior models.

Finally, the `prospect.fitting` submodules have been slightly reorganized.