### PR TITLE
Remove xrange for Py3 compatibility

### DIFF
--- a/prospect/models/parameters.py
+++ b/prospect/models/parameters.py
@@ -205,7 +205,7 @@ class ProspectorParams(object):
                 label.append(name)
                 index.append(inds.start)
             else:
-                for i in xrange(nt):
+                for i in range(nt):
                     label.append(name+'_{0}'.format(i+1))
                     index.append(inds.start+i)
         return [l for (i, l) in sorted(zip(index, label))]
@@ -270,7 +270,7 @@ class ProspectorParams(object):
             Clipped to theta priors.
         """
         bounds = self.theta_bounds()
-        for i in xrange(len(bounds)):
+        for i in range(len(bounds)):
             lower, upper = bounds[i]
             thetas[i] = np.clip(thetas[i], lower, upper)
 


### PR DESCRIPTION
I changed `xrange` to `range` two places I found it to improve Python3 compatibility.  The lines simply generate parameter names for vector parameters with N>1 values, so `range` shouldn't cause any significant overheads.