### PR TITLE
add random seed optional input to fitting.minimizer.minimizer_ball

### DIFF
--- a/prospect/fitting/minimizer.py
+++ b/prospect/fitting/minimizer.py
@@ -177,11 +177,14 @@ def reinitialize(best_guess, model, edge_trunc=0.1, reinit_params=[],
             output[k] = b[0] + prange/2
     return output
 
-def minimizer_ball(center, nminimizers, model):
+def minimizer_ball(center, nminimizers, model, seed=None):
     """Draw initial values from the (1d, separable, independent) priors for
     each parameter.  Requires that priors have the `sample` method available.
     If priors are old-style, draw randomly between min and max.
+
     """
+    rand = np.random.RandomState(seed)
+    
     size = nminimizers
     pinitial = [center]
     if size > 1:
@@ -193,6 +196,6 @@ def minimizer_ball(center, nminimizers, model):
             except AttributeError:
                 bounds = model.theta_bounds()
                 for ind in range(inds.start,inds.stop):
-                    ginitial[:, ind] = np.random.uniform(bounds[ind][0], bounds[ind][1], size - 1)
+                    ginitial[:, ind] = rand.uniform(bounds[ind][0], bounds[ind][1], size - 1)
         pinitial += ginitial.tolist()
     return pinitial

--- a/prospect/models/priors.py
+++ b/prospect/models/priors.py
@@ -2,7 +2,6 @@
 # These return the ln-prior-probability
 import numpy as np
 import scipy.stats
-import warnings
 
 __all__ = ["normal", "tophat", "normal_clipped", "lognormal", "logarithmic",
            "plotting_range",

--- a/prospect/models/priors.py
+++ b/prospect/models/priors.py
@@ -2,6 +2,7 @@
 # These return the ln-prior-probability
 import numpy as np
 import scipy.stats
+import warnings
 
 __all__ = ["normal", "tophat", "normal_clipped", "lognormal", "logarithmic",
            "plotting_range",
@@ -138,7 +139,9 @@ class Prior(object):
             self.update(**kwargs)
         p = self.distribution.pdf(x, *self.args,
                                   loc=self.loc, scale=self.scale)
-        return np.log(p)
+        with np.errstate(invalid='ignore'):
+            lnp = np.log(p)
+        return lnp
 
     def sample(self, nsample=None, **kwargs):
         """Draw a sample from the prior distribution.

--- a/prospect/sources/galaxy_basis.py
+++ b/prospect/sources/galaxy_basis.py
@@ -28,12 +28,13 @@ to_cgs = lsun/(4.0 * np.pi * (pc*10)**2)
 
 class CSPSpecBasis(SSPBasis):
 
-    def __init__(self, compute_vega_mags=False, zcontinuous=1,
+    def __init__(self, compute_vega_mags=False, zcontinuous=1, vactoair_flag=False,
                  reserved_params=['zred', 'sigma_smooth'], **kwargs):
 
         # This is a StellarPopulation object from fsps
         self.csp = fsps.StellarPopulation(compute_vega_mags=compute_vega_mags,
-                                          zcontinuous=zcontinuous)
+                                          zcontinuous=zcontinuous,
+                                          vactoair_flag=vactoair_flag)
         self.reserved_params = reserved_params
         self.params = {}
 
@@ -123,11 +124,12 @@ class CSPBasis(object):
     A class for composite stellar populations, which can be composed from
     multiple versions of parameterized SFHs.  Should replace CSPModel.
     """
-    def __init__(self, compute_vega_mags=False, zcontinuous=1, **kwargs):
+    def __init__(self, compute_vega_mags=False, zcontinuous=1, vactoair_flag=False, **kwargs):
 
         # This is a StellarPopulation object from fsps
         self.csp = fsps.StellarPopulation(compute_vega_mags=compute_vega_mags,
-                                          zcontinuous=zcontinuous)
+                                          zcontinuous=zcontinuous,
+                                          vactoair_flag=vactoair_flag)
         self.params = {}
 
     def get_spectrum(self, outwave=None, filters=None, peraa=False, **params):


### PR DESCRIPTION
This is a simple change which adds a `seed` optional input to `fitting.minimizer.minimizer_ball`, so that the initial values used for the L-M optimization are reproducible.  

I didn't change the `prospector` and `prospector_nest` scripts but can do -- let me know @bd-j.

I needed this because I got an error (pasted below) that has not reappeared, so I can't debug it further!

This PR also fixes #95.
```
[snip]
/usr/local/anaconda3/envs/py35/lib/python3.6/site-packages/scipy/optimize/_numdiff.py:344: RuntimeWarning: invalid value encountered in less
  if np.any((x0 < lb) | (x0 > ub)):
/usr/local/anaconda3/envs/py35/lib/python3.6/site-packages/scipy/optimize/_numdiff.py:344: RuntimeWarning: invalid value encountered in greater
  if np.any((x0 < lb) | (x0 > ub)):
/usr/local/anaconda3/envs/py35/lib/python3.6/site-packages/scipy/optimize/_numdiff.py:103: RuntimeWarning: invalid value encountered in greater_equal
  sign_x0 = (x0 >= 0).astype(float) * 2 - 1
/usr/local/anaconda3/envs/py35/lib/python3.6/site-packages/scipy/optimize/_numdiff.py:401: RuntimeWarning: invalid value encountered in subtract
  df = f2 - f1
Traceback (most recent call last):
  File "/home/ioannis/repos/git/siena-astrophysics/research/redmapper/redmapper-stellar-mass.py", line 670, in <module>
    main()
  File "/home/ioannis/repos/git/siena-astrophysics/research/redmapper/redmapper-stellar-mass.py", line 488, in main
    res = least_squares(chivecfn, pinit, method='lm', x_scale='jac', args=chi2args)
  File "/usr/local/anaconda3/envs/py35/lib/python3.6/site-packages/scipy/optimize/_lsq/least_squares.py", line 903, in least_squares
    max_nfev, x_scale, diff_step)
  File "/usr/local/anaconda3/envs/py35/lib/python3.6/site-packages/scipy/optimize/_lsq/least_squares.py", line 83, in call_minpack
    g = J.T.dot(f)
ValueError: shapes (3,1) and (7,) not aligned: 1 (dim 1) != 7 (dim 0)
```