### PR TITLE
Restart Chains

### DIFF
--- a/prospect/fitting/__init__.py
+++ b/prospect/fitting/__init__.py
@@ -2,7 +2,8 @@ from .ensemble import *
 from .minimizer import *
 from .nested import *
 
-__all__ = ["run_emcee_sampler", "reinitialize_ball", "sampler_ball",
+__all__ = ["run_emcee_sampler", "restart_emcee_sampler",
+           "reinitialize_ball", "sampler_ball",
            "run_nested_sampler",
            "pminimize", "minimizer_ball", "reinitialize",
            "convergence_check"]

--- a/scripts/prospector_restart.py
+++ b/scripts/prospector_restart.py
@@ -22,6 +22,8 @@ clargs = model_setup.parse_args(sargv, argdict=argdict)
 # Result object and Globals
 # ----------
 result, global_obs, global_model = pr.results_from(clargs["restart_from"])
+is_emcee = (len(result["chain"].shape) == 3) & (result["chain"].shape[0] > 1)
+assert is_emcee, "Result file does not have a chain of the proper shape."
 
 # SPS Model instance (with libraries check)
 sps = pr.get_sps(result)
@@ -187,7 +189,7 @@ if __name__ == "__main__":
     initial_positions = result["chain"][:, -1, :]
     guesses = None
     initial_center = initial_positions.mean(axis=0)
-    
+
     # ---------------------
     # Sampling
     # -----------------------

--- a/scripts/prospector_restart.py
+++ b/scripts/prospector_restart.py
@@ -14,7 +14,7 @@ from prospect.likelihood import lnlike_spec, lnlike_phot, write_log, chi_spec, c
 # Read command line arguments
 # --------------
 sargv = sys.argv
-argdict = {'restart_from': ''}
+argdict = {'restart_from': '', 'niter': 1024}
 clargs = model_setup.parse_args(sargv, argdict=argdict)
 
 # ----------
@@ -25,6 +25,7 @@ result, global_obs, global_model = pr.results_from(clargs["restart_from"])
 # SPS Model instance (with libraries check)
 sps = pr.get_sps(result)
 run_params = result["run_params"]
+run_params.update(clargs)
 
 # Noise model (this should be doable via read_results)
 from prospect.models.model_setup import import_module_from_string

--- a/scripts/prospector_restart.py
+++ b/scripts/prospector_restart.py
@@ -14,28 +14,33 @@ from prospect.likelihood import lnlike_spec, lnlike_phot, write_log, chi_spec, c
 # Read command line arguments
 # --------------
 sargv = sys.argv
-argdict = {'param_file': ''}
+argdict = {'restart_from': ''}
 clargs = model_setup.parse_args(sargv, argdict=argdict)
-run_params = model_setup.get_run_params(argv=sargv, **clargs)
 
-# --------------
-# Globals
-# --------------
-# GP instances as global
-spec_noise, phot_noise = model_setup.load_gp(**run_params)
-# Model as global
-global_model = model_setup.load_model(**run_params)
-# Obs as global
-global_obs = model_setup.load_obs(**run_params)
-# SPS Model instance as global
-sps = model_setup.load_sps(**run_params)
+# ----------
+# Result object and Globals
+# ----------
+result, global_obs, global_model = pr.results_from(clargs["restart_from"])
+
+# SPS Model instance (with libraries check)
+sps = pr.get_sps(result)
+run_params = result["run_params"]
+
+# Noise model (this should be doable via read_results)
+from prospect.models.model_setup import import_module_from_string
+param_file = (result['run_params'].get('param_file', ''),
+              result.get("paramfile_text", ''))
+path, filename = os.path.split(param_file[0])
+modname = filename.replace('.py', '')
+user_module = import_module_from_string(param_file[1], modname)
+spec_noise, phot_noise = user_model.load_gp(**run_params)
 
 # -----------------
 # LnP function as global
 # ------------------
 
-def lnprobfn(theta, model=None, obs=None, noise=None, sps=sps,
-             residuals=False, verbose=run_params['verbose']):
+def lnprobfn(theta, model=None, obs=None, residuals=False,
+             verbose=run_params['verbose']):
     """Given a parameter vector and optionally a dictionary of observational
     ata and a model object, return the ln of the posterior. This requires that
     an sps object (and if using spectra and gaussian processes, a GP object) be
@@ -106,21 +111,6 @@ def lnprobfn(theta, model=None, obs=None, noise=None, sps=sps,
     return lnp_prior + lnp_phot + lnp_spec
 
 
-def chisqfn(theta, model, obs):
-    """Negative of lnprobfn for minimization, and also handles passing in
-    keyword arguments which can only be postional arguments when using scipy
-    minimize.
-    """
-    return -lnprobfn(theta, model=model, obs=obs)
-
-
-def chivecfn(theta):
-    """Return the residuals instead of a posterior probability or negative
-    chisq, for use with least-squares optimization methods
-    """
-    return lnprobfn(theta, residuals=True)
-
-
 # -----------------
 # MPI pool.  This must be done *after* lnprob and
 # chi2 are defined since slaves will only see up to
@@ -166,7 +156,6 @@ if __name__ == "__main__":
     # Use the globals
     model = global_model
     obsdat = global_obs
-    chi2args = [None, None]
     postkwargs = {}
 
     # make zeros into tiny numbers
@@ -175,7 +164,7 @@ if __name__ == "__main__":
         halt('stopping for debug')
 
     # Try to set up an HDF5 file and write basic info to it
-    outroot = "{0}_{1}".format(rp['outfile'], int(time.time()))
+    outroot = "{}_restart_{}".format(rp['outfile'], int(time.time()))
     odir = os.path.dirname(os.path.abspath(outroot))
     if (not os.path.exists(odir)):
         halt('Target output directory {} does not exist, please make it.'.format(odir))
@@ -190,51 +179,10 @@ if __name__ == "__main__":
         hfile = None
 
     # -----------------------------------------
-    # Initial guesses using minimization
+    # Initial guesses from end of last chain
     # -----------------------------------------
-    if rp['verbose']:
-        print('Starting minimization...')
 
-    if not np.isfinite(model.prior_product(model.initial_theta.copy())):
-        halt("Halting: initial parameter position has zero prior probability.")
-
-    nmin = rp.get('nmin', 1)
-    if pool is not None:
-        nmin = max([nmin, pool.size])
-
-    if bool(rp.get('do_powell', False)):
-        from prospect.fitting.fitting import run_minimize
-        powell_opt = {'ftol': rp['ftol'], 'xtol': 1e-6, 'maxfev': rp['maxfev']}
-        guesses, pdur, best = run_minimize(obsdat, model, sps, noise=None, lnprobfn=lnprobfn,
-                                           min_method='powell', min_opts={"options": powell_opt},
-                                           nmin=nmin, pool=pool)
-        initial_center = fitting.reinitialize(guesses[best].x, model,
-                                              edge_trunc=rp.get('edge_trunc', 0.1))
-        initial_prob = -guesses[best]['fun']
-        if rp['verbose']:
-            print('done Powell in {0}s'.format(pdur))
-            print('best Powell guess:{0}'.format(initial_center))
-
-    elif bool(rp.get('do_levenberg', False)):
-        from prospect.fitting.fitting import run_minimize
-        lm_opt = {"xtol": 5e-16, "ftol": 5e-16}
-        guesses, pdur, best = run_minimize(obsdat, model, sps, noise=None, lnprobfn=lnprobfn,
-                                           min_method='lm', min_opts=lm_opt,
-                                           nmin=nmin, pool=pool)        
-        initial_center = fitting.reinitialize(guesses[best].x, model,
-                                              edge_trunc=rp.get('edge_trunc', 0.1))
-        initial_prob = None
-        if rp['verbose']:
-            print('done L-M in {0}s'.format(pdur))
-            print('best L-M guess:{0}'.format(initial_center))
-
-    else:
-        if rp['verbose']:
-            print('No minimization requested.')
-        guesses = None
-        pdur = 0.0
-        initial_center = initial_theta.copy()
-        initial_prob = None
+    initial_positions = res["chain"][:, -1, :]
 
     # ---------------------
     # Sampling
@@ -242,10 +190,10 @@ if __name__ == "__main__":
     if rp['verbose']:
         print('emcee sampling...')
     tstart = time.time()
-    out = fitting.run_emcee_sampler(lnprobfn, initial_center, model,
-                                    postkwargs=postkwargs, prob0=initial_prob,
-                                    pool=pool, hdf5=hfile, **rp)
-    esampler, burn_p0, burn_prob0 = out
+    out = fitting.restart_emcee_sampler(lnprobfn, initial_positions, model,
+                                        postkwargs=postkwargs,
+                                        pool=pool, hdf5=hfile, **rp)
+    esampler, _, _ = out
     edur = time.time() - tstart
     if rp['verbose']:
         print('done emcee in {0}s'.format(edur))
@@ -257,16 +205,12 @@ if __name__ == "__main__":
     if rp.get("output_pickles", False):
         write_results.write_pickles(rp, model, obsdat, esampler, guesses,
                                     outroot=outroot, toptimize=pdur, tsample=edur,
-                                    sampling_initial_center=initial_center,
-                                    post_burnin_center=burn_p0,
-                                    post_burnin_prob=burn_prob0)
+                                    sampling_initial_center=initial_center)
     if hfile is None:
         hfile = hfilename
     write_results.write_hdf5(hfile, rp, model, obsdat, esampler, guesses,
                              toptimize=pdur, tsample=edur,
-                             sampling_initial_center=initial_center,
-                             post_burnin_center=burn_p0,
-                             post_burnin_prob=burn_prob0)
+                             sampling_initial_center=initial_center)
     try:
         hfile.close()
     except:


### PR DESCRIPTION
This PR adds the ability to restart `emcee` sampling through a new `prospector_restart.py` script and an additional `fitting.ensemble` sampling wrapper.  The random number generator is not yet propagated through to the restarted chains.

This PR also includes a fairly significant refactor of the `fitting.ensemble` methods.

This has been smoke tested but not tested for correctness of results.