### PR TITLE
Fix for python2.x/3.x incompatibility in library checking.

### DIFF
--- a/prospect/io/read_results.py
+++ b/prospect/io/read_results.py
@@ -291,6 +291,12 @@ def get_sps(res):
     else:
         liberr = ("The FSPS libraries used in fitting({}) are not the "
                   "same as the FSPS libraries that you are using now ({})".format(flib, rlib))
+        # If fitting and reading in are happening in different python versions,
+        # ensure string comparison doesn't throw error:
+        if type(flib[0]) == 'bytes':
+            flib = [i.decode() for i in flib]
+        if type(rlib[0]) == 'bytes':
+            rlib = [i.decode() for i in rlib]
         assert (flib[0] == rlib[0]) and (flib[1] == rlib[1]), liberr
 
     return sps


### PR DESCRIPTION
Ultimately I found that this quick fix is likely the most flexible, because it is tricky (and unnecessary) to check which version of python the original fits were carried out in. This simply decides whether the current libraries or fitting libraries are being stored as bytes and coerces everything to string. 

I can make this  a function if desired, but it seemed short enough just to merge into the current function. 