### PR TITLE
SpecModel bug fix

### DIFF
--- a/prospect/models/sedmodel.py
+++ b/prospect/models/sedmodel.py
@@ -262,7 +262,7 @@ class SpecModel(ProspectorParams):
             ndarray of shape ``(nwave,)`` in units of maggies.
         """
         # redshift wavelength
-        obs_wave = self.observed_wave(self._wave, do_wavecal=True)
+        obs_wave = self.observed_wave(self._wave, do_wavecal=False)
         self._outwave = obs.get('wavelength', obs_wave)
 
         # cache eline parameters


### PR DESCRIPTION
When using PolySpecModel, a NotImplementedError is raised. This fixes it by setting do_wavecal=False when calling SpecModel.observed_wave( )