### PR TITLE
avoid comparing to booleans using 'is'

### DIFF
--- a/prospect/models/parameters.py
+++ b/prospect/models/parameters.py
@@ -210,7 +210,7 @@ class ProspectorParams(object):
         value depends on another parameter, calculate those values and store
         them in the :py:attr:`self.params` dictionary.
         """
-        if self._has_parameter_dependencies is False:
+        if self._has_parameter_dependencies == False:
             return
         for p, info in list(self.config_dict.items()):
             if 'depends_on' in info:
@@ -247,7 +247,7 @@ class ProspectorParams(object):
         ``config_dict``.
         """
         return [k['name'] for k in pdict_to_plist(self.config_list)
-                if (k.get('isfree', False) is False)]
+                if (k.get('isfree', False) == False)]
 
     @property
     def description(self):

--- a/prospect/models/sedmodel.py
+++ b/prospect/models/sedmodel.py
@@ -283,7 +283,7 @@ class SpecModel(ProspectorParams):
             calibrated_spec[emask] += self._elinespec.sum(axis=1)
         # Otherwise, if FSPS is not adding emission lines to the spectrum, we
         # add emission lines to valid pixels here.
-        elif (self.params.get("nebemlineinspec", True) is False) & (emask.any()):
+        elif (self.params.get("nebemlineinspec", True) == False) & (emask.any()):
             self._elinespec = self.get_eline_spec(wave=self._wave[emask])
             if emask.any():
                 calibrated_spec[emask] += self._elinespec.sum(axis=1)
@@ -321,7 +321,7 @@ class SpecModel(ProspectorParams):
         phot = np.atleast_1d(10**(-0.4 * mags))
 
         # generate emission-line photometry
-        if self.params.get('nebemlineinspec', False) is False:
+        if self.params.get('nebemlineinspec', False) == False:
             phot += self.nebline_photometry(filters)
 
         return phot
@@ -469,8 +469,8 @@ class SpecModel(ProspectorParams):
         """
         # ensure we have no emission lines in spectrum
         # and we definitely want them.
-        assert self.params['nebemlineinspec'] is False
-        assert self.params['add_neb_emission'] is True
+        assert self.params['nebemlineinspec'] == False
+        assert self.params['add_neb_emission'] == True
 
         # generate Gaussians on appropriate wavelength gride
         idx = self._elines_to_fit


### PR DESCRIPTION
Boolean comparison using "is" always evaluates to False in some cases (suspect this is related to Python base version). This updates "is" to "==" for consistency.