### PR TITLE
add an informative error message when mpi4py fails to import

### DIFF
--- a/demo/demo_mpi_params.py
+++ b/demo/demo_mpi_params.py
@@ -312,6 +312,7 @@ if __name__ == '__main__':
 
         withmpi = comm.Get_size() > 1
     except ImportError:
+        print('Failed to start MPI; are mpi4py and schwimmbad installed? Proceeding without MPI.')
         withmpi = False
 
     # Evaluate SPS over logzsol grid in order to get necessary data in cache/memory


### PR DESCRIPTION
better to be explicit about all things MPI, to save debugging time