### PR TITLE
FilterSet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,17 @@ and/or spectroscopic data.  Prospector allows you to:
   calibration, including spectrophotometric calibration and wavelength solution,
   thus properly incorporating uncertainties in these components in the final parameter uncertainties.
 
-Read the documentation [here](http://prospect.readthedocs.io/en/latest/).
+Read the [documentation](http://prospect.readthedocs.io/en/latest/) and the
+code [paper](https://ui.adsabs.harvard.edu/abs/2020arXiv201201426J/abstract).
 
 Installation
 ------------
 
-To install to a conda environment with dependencies, see `conda_install.sh`.
+See [installation](doc/installation.rst) for requirements and dependencies.
+The [documentation](http://prospect.readthedocs.io/en/latest/) includes a tutorial and demos.
 
-To install just Prospector:
+To install to a conda environment with dependencies, see `conda_install.sh`.
+To install just Prospector (stable release):
 ```
 python -m pip install astro-prospector
 ```
@@ -34,18 +37,35 @@ cd prospector
 python -m pip install .
 ```
 
-Then in Python
+Then, in Python
 ```python
 import prospect
 ```
 
-See [installation](doc/installation.rst) for requirements.
-Other files in the [doc/](doc/) directory explain the usage of the code,
-and you can read the documentation [here](http://prospect.readthedocs.io/en/latest/).
 
-See also the [tutorial](demo/tutorial.rst)
-or the [interactive demo](demo/InteractiveDemo.ipynb)
-for fitting photometric data with composite stellar populations.
+Citation
+------
+
+If you use this code, please reference [this paper](https://ui.adsabs.harvard.edu/abs/2020arXiv201201426J/abstract):
+```
+@ARTICLE{2020arXiv201201426J,
+       author = {{Johnson}, Benjamin D. and {Leja}, Joel and {Conroy}, Charlie and {Speagle}, Joshua S.},
+        title = "{Stellar Population Inference with Prospector}",
+      journal = {arXiv e-prints},
+     keywords = {Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics},
+         year = 2020,
+        month = dec,
+          eid = {arXiv:2012.01426},
+        pages = {arXiv:2012.01426},
+archivePrefix = {arXiv},
+       eprint = {2012.01426},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2020arXiv201201426J},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+```
+
+and make sure to cite the dependencies as listed in [installation](doc/installation.rst)
 
 Example
 -------
@@ -53,42 +73,3 @@ Example
 Inference with mock broadband data, showing the change in posteriors as the
 number of photometric bands is increased.
 ![Demonstration of posterior inference with increasing number of photometric bands](doc/images/animation.gif)
-
-Citation
-------
-
-If you use this code, please reference
-```
-@MISC{2019ascl.soft05025J,
-       author = {{Johnson}, Benjamin D. and {Leja}, Joel L. and {Conroy}, Charlie and
-         {Speagle}, Joshua S.},
-        title = "{Prospector: Stellar population inference from spectra and SEDs}",
-     keywords = {Software},
-         year = 2019,
-        month = may,
-          eid = {ascl:1905.025},
-        pages = {ascl:1905.025},
-archivePrefix = {ascl},
-       eprint = {1905.025},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2019ascl.soft05025J},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-```
-
-and make sure to cite the dependencies as listed in [installation](doc/installation.rst)
-
-You should also cite:
-
-```
-@article{2017ApJ...837..170L,
-   author = {{Leja}, J. and {Johnson}, B.~D. and {Conroy}, C. and {van Dokkum}, P.~G. and {Byler}, N.},
-   title = "{Deriving Physical Properties from Broadband Photometry with Prospector: Description of the Model and a Demonstration of its Accuracy Using 129 Galaxies in the Local Universe}",
-   journal = {\apj},
-   year = 2017,
-   volume = 837,
-   pages = {170},
-   eprint = {1609.09073},
-   doi = {10.3847/1538-4357/aa5ffe},
-  adsurl = {http://adsabs.harvard.edu/abs/2017ApJ...837..170L},
-}
-```

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,9 +15,9 @@ Prospector allows you to:
   SFHs).
 
 * Forward model many aspects of spectroscopic data analysis and calibration,
-  including spectral resolution, spectrophotometric calibration, sky emission
-  (coming soon), and wavelength solution, thus properly incorporating
-  uncertainties in these components in the final parameter uncertainties.
+  including spectral resolution, spectrophotometric calibration and wavelength
+  solution, thus properly incorporating uncertainties in these components in the
+  final parameter uncertainties.
 
 
 .. toctree::
@@ -52,27 +52,27 @@ Prospector allows you to:
 License and Attribution
 ------------------------------
 
-*Copyright 2014-2020 Benjamin D. Johnson and contributors.*
+*Copyright 2014-2021 Benjamin D. Johnson and contributors.*
 
 This code is available under the `MIT License
 <https://raw.github.com/bdj/prospector/blob/main/LICENSE>`_.
 
-If you use this code, please reference
+If you use this code, please reference `this paper <https://ui.adsabs.harvard.edu/abs/2020arXiv201201426J/abstract>`_:
 
 .. code-block:: none
 
-        @MISC{2019ascl.soft05025J,
-            author = {{Johnson}, Benjamin D. and {Leja}, Joel L. and {Conroy}, Charlie and
-                {Speagle}, Joshua S.},
-                title = "{Prospector: Stellar population inference from spectra and SEDs}",
-            keywords = {Software},
-                year = 2019,
-                month = may,
-                eid = {ascl:1905.025},
-                pages = {ascl:1905.025},
-        archivePrefix = {ascl},
-            eprint = {1905.025},
-            adsurl = {https://ui.adsabs.harvard.edu/abs/2019ascl.soft05025J},
-            adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-        }
-
+    @ARTICLE{2020arXiv201201426J,
+        author = {{Johnson}, Benjamin D. and {Leja}, Joel and {Conroy}, Charlie and {Speagle}, Joshua S.},
+            title = "{Stellar Population Inference with Prospector}",
+        journal = {arXiv e-prints},
+        keywords = {Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics},
+            year = 2020,
+            month = dec,
+            eid = {arXiv:2012.01426},
+            pages = {arXiv:2012.01426},
+    archivePrefix = {arXiv},
+        eprint = {2012.01426},
+    primaryClass = {astro-ph.GA},
+        adsurl = {https://ui.adsabs.harvard.edu/abs/2020arXiv201201426J},
+        adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+    }

--- a/prospect/fitting/fitting.py
+++ b/prospect/fitting/fitting.py
@@ -48,7 +48,7 @@ def lnprobfn(theta, model=None, obs=None, sps=None, noise=(None, None),
           + ``"unc"``         (maggies)
           + ``"maggies"``     (photometry in maggies)
           + ``"maggies_unc"`` (photometry uncertainty in maggies)
-          + ``"filters"``     (iterable of :py:class:`sedpy.observate.Filter`)
+          + ``"filters"``     (:py:class:`sedpy.observate.FilterSet` or iterable of :py:class:`sedpy.observate.Filter`)
           +  and optional spectroscopic ``"mask"`` and ``"phot_mask"``
              (same length as ``spectrum`` and ``maggies`` respectively,
              True means use the data points)

--- a/prospect/likelihood/likelihood.py
+++ b/prospect/likelihood/likelihood.py
@@ -121,7 +121,10 @@ def lnlike_phot(phot_mu, obs=None, phot_noise=None, f_outlier_phot=0.0, **vector
     var = (obs['maggies_unc'][mask])**2
 
     if phot_noise is not None:
-        filternames = [f.name for f in obs['filters']]
+        try:
+            filternames = obs['filters'].filternames
+        except(AttributeError):
+            filternames = [f.name for f in obs['filters']]
         vectors['mask'] = mask
         vectors['filternames'] = np.array(filternames)
         try:

--- a/prospect/models/sedmodel.py
+++ b/prospect/models/sedmodel.py
@@ -144,7 +144,7 @@ class SpecModel(ProspectorParams):
             calibrated_spec[emask] += self._elinespec.sum(axis=1)
         # Otherwise, if FSPS is not adding emission lines to the spectrum, we
         # add emission lines to valid pixels here.
-        elif (self.params.get("nebemlineinspec", True) == False) & (emask.any()):
+        elif (bool(self.params.get("nebemlineinspec", True)) is False) & (emask.any()):
             self._elinespec = self.get_eline_spec(wave=self._outwave[emask])
             if emask.any():
                 calibrated_spec[emask] += self._elinespec.sum(axis=1)
@@ -204,7 +204,7 @@ class SpecModel(ProspectorParams):
         :param elums: (optional)
             The emission line flux in erg/s/cm^2.  If not supplied uses  the
             cached ``_eline_lum`` attribute and applies appropriate distance
-            dimming and unit conversion 
+            dimming and unit conversion.
 
         :returns nebflux:
             The flux of the emission line through the filters, in units of
@@ -221,7 +221,7 @@ class SpecModel(ProspectorParams):
         try:
             # TODO: Since in this case filters are on a grid, there should be a
             # faster way to look up the transmission than the later loop
-            flist = filters.filters:
+            flist = filters.filters
         except(AttributeError):
             flist = filters
         for i, filt in enumerate(flist):
@@ -513,7 +513,7 @@ class SpecModel(ProspectorParams):
         fmaggies = self._norm_spec / (1 + self._zred) * (ld / 10)**2
         # convert to erg/s/cm^2/AA for sedpy and get absolute magnitudes
         flambda = fmaggies * lightspeed / self._wave**2 * (3631*jansky_cgs)
-        abs_rest_maggies = np.atleast_1d(getSED(self._wave, flambda, filters, linear_flux=True)))
+        abs_rest_maggies = np.atleast_1d(getSED(self._wave, flambda, filters, linear_flux=True))
 
         # add emission lines
         if bool(self.params.get('nebemlineinspec', False)) is False:

--- a/prospect/sources/galaxy_basis.py
+++ b/prospect/sources/galaxy_basis.py
@@ -132,7 +132,7 @@ class MultiComponentCSPBasis(CSPSpecBasis):
     tracked, and in get_spectrum() photometry can be drawn from a given
     component or from the sum.
     """
-    
+
     def get_galaxy_spectrum(self, **params):
         """Update parameters, then loop over each component getting a spectrum
         for each.  Return all the component spectra, plus the sum.
@@ -233,14 +233,7 @@ class MultiComponentCSPBasis(CSPSpecBasis):
 
         # Observed frame photometry, as absolute maggies
         if filters is not None:
-            # Magic to only do filter projections for unique filters, and get a
-            # mapping back into this list of unique filters
-            # note that this may scramble order of unique_filters
-            fnames = [f.name for f in filters]
-            unique_names, uinds, filter_ind = np.unique(fnames, return_index=True, return_inverse=True)
-            unique_filters = np.array(filters)[uinds]
-            mags = getSED(wa, lightspeed/wa**2 * sa * to_cgs, unique_filters)
-            phot = np.atleast_1d(10**(-0.4 * mags))
+            phot = np.atleast_1d(getSED(wa, lightspeed/wa**2 * sa * to_cgs, filters), linear_flux=True)
         else:
             phot = 0.0
             filter_ind = 0
@@ -266,7 +259,7 @@ class MultiComponentCSPBasis(CSPSpecBasis):
         mass = np.squeeze(mass.tolist() + [mass.sum()])
 
         sa = (sa * mass[:, None])
-        phot = (phot * mass[:, None])[component, filter_ind]
+        phot = (phot * mass[:, None])[component, :]
 
         return sa, phot, mfrac
 

--- a/prospect/sources/ssp_basis.py
+++ b/prospect/sources/ssp_basis.py
@@ -150,10 +150,10 @@ class SSPBasis(object):
         predicted by FSPS. These lines are in units of Lsun/solar mass formed.
         This assumes that `get_galaxy_spectrum` has already been called.
 
-        :returns ewave: 
+        :returns ewave:
             The *restframe* wavelengths of the emission lines, AA
 
-        :returns elum: 
+        :returns elum:
             Specific luminosities of the nebular emission lines,
             Lsun/stellar mass formed
         """
@@ -171,7 +171,7 @@ class SSPBasis(object):
                 # tabular sfh
                 mass = np.sum(self.params.get('mass', 1.0))
                 elum /= mass
-        
+
         return ewave, elum
 
     def get_spectrum(self, outwave=None, filters=None, peraa=False, **params):
@@ -186,7 +186,7 @@ class SSPBasis(object):
             maggies.
 
         :param filters: (default: None)
-            A list of filter objects for which you'd like photometry to be calculated. 
+            A list of filter objects for which you'd like photometry to be calculated.
 
         :param **params:
             Optional keywords giving parameter values that will be used to
@@ -224,8 +224,8 @@ class SSPBasis(object):
 
         # Observed frame photometry, as absolute maggies
         if filters is not None:
-            mags = getSED(wa, lightspeed/wa**2 * sa * to_cgs, filters)
-            phot = np.atleast_1d(10**(-0.4 * mags))
+            phot = np.atleast_1d(getSED(wa, lightspeed/wa**2 * sa * to_cgs,
+                                        filters, linear_flux=True))
         else:
             phot = 0.0
 


### PR DESCRIPTION
WIP

Adding support for `sedpy.observate.FilterSet` objects.  This will enable faster projections when those are the bottlenecks.  However, maintaining speed also requires some changes to `SpecModel.nebline_photometry`.

Need to maintain support for simple lists of `Filter` objects.