### PR TITLE
Support for sedpy FilterSets

### DIFF
--- a/prospect/fitting/fitting.py
+++ b/prospect/fitting/fitting.py
@@ -48,7 +48,7 @@ def lnprobfn(theta, model=None, obs=None, sps=None, noise=(None, None),
           + ``"unc"``         (maggies)
           + ``"maggies"``     (photometry in maggies)
           + ``"maggies_unc"`` (photometry uncertainty in maggies)
-          + ``"filters"``     (iterable of :py:class:`sedpy.observate.Filter`)
+          + ``"filters"``     (:py:class:`sedpy.observate.FilterSet` or iterable of :py:class:`sedpy.observate.Filter`)
           +  and optional spectroscopic ``"mask"`` and ``"phot_mask"``
              (same length as ``spectrum`` and ``maggies`` respectively,
              True means use the data points)

--- a/prospect/likelihood/likelihood.py
+++ b/prospect/likelihood/likelihood.py
@@ -121,7 +121,10 @@ def lnlike_phot(phot_mu, obs=None, phot_noise=None, f_outlier_phot=0.0, **vector
     var = (obs['maggies_unc'][mask])**2
 
     if phot_noise is not None:
-        filternames = [f.name for f in obs['filters']]
+        try:
+            filternames = obs['filters'].filternames
+        except(AttributeError):
+            filternames = [f.name for f in obs['filters']]
         vectors['mask'] = mask
         vectors['filternames'] = np.array(filternames)
         try:

--- a/prospect/models/sedmodel.py
+++ b/prospect/models/sedmodel.py
@@ -144,7 +144,7 @@ class SpecModel(ProspectorParams):
             calibrated_spec[emask] += self._elinespec.sum(axis=1)
         # Otherwise, if FSPS is not adding emission lines to the spectrum, we
         # add emission lines to valid pixels here.
-        elif (self.params.get("nebemlineinspec", True) == False) & (emask.any()):
+        elif (bool(self.params.get("nebemlineinspec", True)) is False) & (emask.any()):
             self._elinespec = self.get_eline_spec(wave=self._outwave[emask])
             if emask.any():
                 calibrated_spec[emask] += self._elinespec.sum(axis=1)
@@ -164,8 +164,9 @@ class SpecModel(ProspectorParams):
 
 
         :param filters:
-            List of :py:class:`sedpy.observate.Filter` objects.
-            If there is no photometry, ``None`` should be supplied
+            Instance of :py:class:`sedpy.observate.FilterSet` or list of
+            :py:class:`sedpy.observate.Filter` objects. If there is no
+            photometry, ``None`` should be supplied.
 
         :returns phot:
             Observed frame photometry of the model SED through the given filters.
@@ -178,8 +179,9 @@ class SpecModel(ProspectorParams):
         # generate photometry w/o emission lines
         obs_wave = self.observed_wave(self._wave, do_wavecal=False)
         flambda = self._norm_spec * lightspeed / obs_wave**2 * (3631*jansky_cgs)
-        mags = getSED(obs_wave, flambda, filters)
-        phot = np.atleast_1d(10**(-0.4 * mags))
+        phot = 10**(-0.4 * np.atleast_1d(getSED(obs_wave, flambda, filters)))
+        # TODO: below is faster for sedpy > 0.2.0
+        #phot = np.atleast_1d(getSED(obs_wave, flambda, filters, linear_flux=True))
 
         # generate emission-line photometry
         if bool(self.params.get('nebemlineinspec', False)) is False:
@@ -187,27 +189,44 @@ class SpecModel(ProspectorParams):
 
         return phot
 
-    def nebline_photometry(self, filters):
+    def nebline_photometry(self, filters, elams=None, elums=None):
         """Compute the emission line contribution to photometry.  This requires
         several cached attributes:
           + ``_ewave_obs``
           + ``_eline_lum``
 
         :param filters:
-            List of :py:class:`sedpy.observate.Filter` objects
+            Instance of :py:class:`sedpy.observate.FilterSet` or list of
+            :py:class:`sedpy.observate.Filter` objects
+
+        :param elams: (optional)
+            The emission line wavelength in angstroms.  If not supplied uses the
+            cached ``_ewave_obs`` attribute.
+
+        :param elums: (optional)
+            The emission line flux in erg/s/cm^2.  If not supplied uses  the
+            cached ``_eline_lum`` attribute and applies appropriate distance
+            dimming and unit conversion.
 
         :returns nebflux:
             The flux of the emission line through the filters, in units of
             maggies. ndarray of shape ``(len(filters),)``
         """
-        elams = self._ewave_obs
-        # We have to remove the extra (1+z) since this is flux, not a flux density
-        # Also we convert to cgs
-        elums = self._eline_lum * self.flux_norm() / (1 + self._zred) * (3631*jansky_cgs)
+        if (elams is None) or (elums is None):
+            elams = self._ewave_obs
+            # We have to remove the extra (1+z) since this is flux, not a flux density
+            # Also we convert to cgs
+            elums = self._eline_lum * self.flux_norm() / (1 + self._zred) * (3631*jansky_cgs)
 
         # loop over filters
         flux = np.zeros(len(filters))
-        for i, filt in enumerate(filters):
+        try:
+            # TODO: Since in this case filters are on a grid, there should be a
+            # faster way to look up the transmission than the later loop
+            flist = filters.filters
+        except(AttributeError):
+            flist = filters
+        for i, filt in enumerate(flist):
             # calculate transmission at line wavelengths
             trans = np.interp(elams, filt.wavelength, filt.transmission,
                               left=0., right=0.)
@@ -496,22 +515,17 @@ class SpecModel(ProspectorParams):
         fmaggies = self._norm_spec / (1 + self._zred) * (ld / 10)**2
         # convert to erg/s/cm^2/AA for sedpy and get absolute magnitudes
         flambda = fmaggies * lightspeed / self._wave**2 * (3631*jansky_cgs)
-        abs_rest_maggies = np.atleast_1d(10**(-0.4 * getSED(self._wave, flambda, filters)))
+        abs_rest_maggies = 10**(-0.4 * np.atleast_1d(getSED(self._wave, flambda, filters)))
+        # TODO: below is faster for sedpy > 0.2.0
+        #abs_rest_maggies = np.atleast_1d(getSED(self._wave, flambda, filters, linear_flux=True))
 
         # add emission lines
         if bool(self.params.get('nebemlineinspec', False)) is False:
             eline_z = self.params.get("eline_delta_zred", 0.0)
             elams = (1 + eline_z) * self._eline_wave
             elums = self._eline_lum * self.flux_norm() / (1 + self._zred) * (3631*jansky_cgs) * (ld / 10)**2
-            flux = np.zeros(len(filters))
-            for i, filt in enumerate(filters):
-                # calculate transmission at line wavelengths
-                trans = np.interp(elams, filt.wavelength, filt.transmission,
-                                  left=0., right=0.)
-                # include all lines where transmission is non-zero
-                idx = (trans > 0)
-                if True in idx:
-                    abs_rest_maggies[i] += (trans[idx]*elams[idx]*elums[idx]).sum() / filt.ab_zero_counts
+            emaggies = self.nebline_photometry(filters, elams=elams, elums=elums)
+            abs_rest_maggies += emaggies
 
         return abs_rest_maggies
 

--- a/prospect/sources/ssp_basis.py
+++ b/prospect/sources/ssp_basis.py
@@ -150,10 +150,10 @@ class SSPBasis(object):
         predicted by FSPS. These lines are in units of Lsun/solar mass formed.
         This assumes that `get_galaxy_spectrum` has already been called.
 
-        :returns ewave: 
+        :returns ewave:
             The *restframe* wavelengths of the emission lines, AA
 
-        :returns elum: 
+        :returns elum:
             Specific luminosities of the nebular emission lines,
             Lsun/stellar mass formed
         """
@@ -171,7 +171,7 @@ class SSPBasis(object):
                 # tabular sfh
                 mass = np.sum(self.params.get('mass', 1.0))
                 elum /= mass
-        
+
         return ewave, elum
 
     def get_spectrum(self, outwave=None, filters=None, peraa=False, **params):
@@ -186,7 +186,7 @@ class SSPBasis(object):
             maggies.
 
         :param filters: (default: None)
-            A list of filter objects for which you'd like photometry to be calculated. 
+            A list of filter objects for which you'd like photometry to be calculated.
 
         :param **params:
             Optional keywords giving parameter values that will be used to
@@ -224,8 +224,11 @@ class SSPBasis(object):
 
         # Observed frame photometry, as absolute maggies
         if filters is not None:
-            mags = getSED(wa, lightspeed/wa**2 * sa * to_cgs, filters)
-            phot = np.atleast_1d(10**(-0.4 * mags))
+            flambda = lightspeed/wa**2 * sa * to_cgs
+            phot = 10**(-0.4 * np.atleast_1d(getSED(wa, flambda, filters)))
+            # TODO: below is faster for sedpy > 0.2.0
+            #phot = np.atleast_1d(getSED(wa, lightspeed/wa**2 * sa * to_cgs,
+            #                            filters, linear_flux=True))
         else:
             phot = 0.0
 


### PR DESCRIPTION
Adding support for sedpy.observate.FilterSet objects. This will enable faster projections when those are the bottlenecks. However, maintaining speed also required some changes to SpecModel.nebline_photometry.

Need to maintain support for simple lists of Filter objects.

Would be a good opportunity to add some tests.