### PR TITLE
allow sigma_smooth to adjust photometry

### DIFF
--- a/prospect/models/sedmodel.py
+++ b/prospect/models/sedmodel.py
@@ -5,6 +5,7 @@
 observed spectra and photometry from them, given a Source object.
 """
 
+from copy import deepcopy
 import numpy as np
 import os
 from numpy.polynomial.chebyshev import chebval, chebvander
@@ -93,6 +94,9 @@ class SpecModel(ProspectorParams):
         # Flux normalize
         self._norm_spec = self._spec * self.flux_norm()
 
+        # Smooth and put on the output wavelength grid
+        self._smooth_spec = self.smoothspec(obs_wave, self._norm_spec)
+
         # generate spectrum and photometry for likelihood
         # predict_spec should be called before predict_phot
         # because in principle it can modify the emission line parameters
@@ -150,8 +154,8 @@ class SpecModel(ProspectorParams):
         # --- cache eline parameters ---
         self.cache_eline_parameters(obs)
 
-        # --- smooth and put on output wavelength grid ---
-        smooth_spec = self.smoothspec(obs_wave, self._norm_spec)
+        # --- copy smooth_spec ---
+        smooth_spec = deepcopy(self._smooth_spec)
 
         # --- add fixed lines if necessary ---
         emask = self._fix_eline_pixelmask
@@ -183,7 +187,7 @@ class SpecModel(ProspectorParams):
         present and correct:
           + ``_wave`` - The SPS restframe wavelength array
           + ``_zred`` - Redshift
-          + ``_norm_spec`` - Observed frame spectral fluxes, in units of maggies.
+          + ``_smooth_spec`` - Smoothed observed frame spectral fluxes, in units of maggies.
           + ``_ewave_obs`` and ``_eline_lum`` - emission line parameters from
             the SPS model
 
@@ -202,7 +206,7 @@ class SpecModel(ProspectorParams):
 
         # generate photometry w/o emission lines
         obs_wave = self.observed_wave(self._wave, do_wavecal=False)
-        flambda = self._norm_spec * lightspeed / obs_wave**2 * (3631*jansky_cgs)
+        flambda = self._smooth_spec * lightspeed / obs_wave**2 * (3631*jansky_cgs)
         phot = 10**(-0.4 * np.atleast_1d(getSED(obs_wave, flambda, filters)))
         # TODO: below is faster for sedpy > 0.2.0
         #phot = np.atleast_1d(getSED(obs_wave, flambda, filters, linear_flux=True))


### PR DESCRIPTION
Currently, `SpecModel` does not respect the user's `sigma_smooth` parameter when predicting photometry; photometry is always computed based on a smoothed spectrum with `sigma_smooth` set to the [default of 100 km s⁻¹](https://github.com/bd-j/prospector/blob/2a6694089800ce617465c489096ecbef56ba9d40/prospect/models/sedmodel.py#L540). This edit should allow the user's `sigma_smooth` parameter to adjust the photometry as one would expect.

However, it should be noted that `nebline_photometry` also does not respect `sigma_smooth` and that is not addressed by this edit, and thus the predicted photometry is likely incorrect in the case where `nebemlineinspec == False` and `sigma_smooth != 100`.