### PR TITLE
new template SFH from Suess+21

### DIFF
--- a/prospect/fitting/fitting.py
+++ b/prospect/fitting/fitting.py
@@ -112,6 +112,11 @@ def lnprobfn(theta, model=None, obs=None, sps=None, noise=(None, None),
     except:
         print("There was an error during the likelihood call at parameters {}".format(theta))
         raise
+        
+    # --- check to make sure agebins have minimum spacing of 1million yrs ---
+    #       (this can happen in flex models and will crash FSPS)
+    if np.min(np.diff(10**model.params['agebins'])) < 1e6:
+        return lnnull    
 
     # --- Optionally return chi vectors for least-squares ---
     # note this does not include priors!

--- a/prospect/models/templates.py
+++ b/prospect/models/templates.py
@@ -557,7 +557,6 @@ _nonpar_continuity_psb_ = TemplateLibrary["ssp"]
 _ = _nonpar_continuity_psb_.pop("tage")
 
 _nonpar_continuity_psb_["sfh"] = {"N": 1, "isfree": False, "init": 3, "units": "FSPS index"}
-#_nonpar_continuity_flex_["tuniv"]      = {"N": 1, "isfree": False, "init": 13.7, "units": "Gyr"}
 
 # This is the *total*  mass formed
 _nonpar_continuity_psb_["logmass"] = {"N": 1, "isfree": True, "init": 10, 'units': 'Msun',
@@ -568,10 +567,10 @@ _nonpar_continuity_psb_["logmass"] = {"N": 1, "isfree": True, "init": 10, 'units
 # the youngest bin has variable width tlast. tflex is specified by the user, and
 # sets the amount of time available for the flexible+youngest bins (e.g., t_lookback=tflex
 # is the time when the SFH transitions from fixed to flexible bins)  
-model_params['tflex'] = {'name':'tflex', 'N':1, 'isfree': False, 'init':2, 'units':'Gyr'}          
-model_params['nflex'] = {'name':'nflex', 'N':1, 'isfree': False, 'init':5}          
-model_params['nfixed'] = {'name':'nfixed', 'N':1, 'isfree': False, 'init':3}  
-model_params['tlast'] = {'name':'tlast', 'N':1, 'isfree':True,
+_nonpar_continuity_psb_['tflex'] = {'name':'tflex', 'N':1, 'isfree': False, 'init':2, 'units':'Gyr'}          
+_nonpar_continuity_psb_['nflex'] = {'name':'nflex', 'N':1, 'isfree': False, 'init':5}          
+_nonpar_continuity_psb_['nfixed'] = {'name':'nfixed', 'N':1, 'isfree': False, 'init':3}  
+_nonpar_continuity_psb_['tlast'] = {'name':'tlast', 'N':1, 'isfree':True,
     'init':.2, 'prior':priors.TopHat(mini=.01, maxi=1.5)}                                  
                                        
 # These variables control the ratio of SFRs in adjacent bins

--- a/prospect/models/templates.py
+++ b/prospect/models/templates.py
@@ -547,6 +547,61 @@ _nonpar_continuity_flex_["agebins"]    = {'N': 4, 'isfree': False,
 TemplateLibrary["continuity_flex_sfh"] = (_nonpar_continuity_flex_,
                                           ("Non-parameteric SFH fitting for mass in flexible time "
                                            "bins with a smoothness prior"))
+                                           
+# ----------------------------
+# --- PSB Continuity SFH ----
+# ----------------------------
+# A non-parametric SFH model of mass in Nfixed fixed bins and Nflex flexible time bins with a smoothness prior. Model described in detail in Suess et al. (2021).
+
+_nonpar_continuity_psb_ = TemplateLibrary["ssp"]
+_ = _nonpar_continuity_psb_.pop("tage")
+
+_nonpar_continuity_psb_["sfh"] = {"N": 1, "isfree": False, "init": 3, "units": "FSPS index"}
+#_nonpar_continuity_flex_["tuniv"]      = {"N": 1, "isfree": False, "init": 13.7, "units": "Gyr"}
+
+# This is the *total*  mass formed
+_nonpar_continuity_psb_["logmass"] = {"N": 1, "isfree": True, "init": 10, 'units': 'Msun',
+                                       'prior': priors.TopHat(mini=7, maxi=12)}
+                                       
+# set up the total number of bins that we want in our SFH. 
+# there are nfixed "oldest" bins, one "youngest" bin, and nflex flexible bins in between
+# the youngest bin has variable width tlast. tflex is specified by the user, and
+# sets the amount of time available for the flexible+youngest bins (e.g., t_lookback=tflex
+# is the time when the SFH transitions from fixed to flexible bins)  
+model_params['tflex'] = {'name':'tflex', 'N':1, 'isfree': False, 'init':2, 'units':'Gyr'}          
+model_params['nflex'] = {'name':'nflex', 'N':1, 'isfree': False, 'init':5}          
+model_params['nfixed'] = {'name':'nfixed', 'N':1, 'isfree': False, 'init':3}  
+model_params['tlast'] = {'name':'tlast', 'N':1, 'isfree':True,
+    'init':.2, 'prior':priors.TopHat(mini=.01, maxi=1.5)}                                  
+                                       
+# These variables control the ratio of SFRs in adjacent bins
+# there is one for a fixed "youngest" bin, nfixed for nfixed "oldest" bins, 
+# and (nflex-1) for nflex flexible bins in between
+_nonpar_continuity_psb_["logsfr_ratio_young"] = {'N': 1, 'isfree': True, 'init': 0.0, 'units': r'dlogSFR (dex)',
+                                                  'prior': priors.StudentT(mean=0.0, scale=0.3, df=2)}
+_nonpar_continuity_psb_["logsfr_ratio_old"] = {'N': 3, 'isfree': True, 'init': np.zeros(3), 'units': r'dlogSFR (dex)',
+                                                'prior': priors.StudentT(mean=np.zeros(3), scale=np.ones(3)*0.3, df=np.ones(3))}
+_nonpar_continuity_psb_["logsfr_ratios"] = {'N': 4, 'isfree': True, 'init': np.zeros(4), 'units': r'dlogSFR (dex)',
+                                             'prior': priors.StudentT(mean=np.zeros(4), scale=0.3*np.ones(4), df=np.ones(4))}
+
+# This will be the mass in each bin.  It depends on other free and fixed
+# parameters.  Its length needs to be modified based on the total number of
+# bins (including fixed young and old bin)
+_nonpar_continuity_psb_["mass"] = {'N': 9, 'isfree': False, 'init': 1e6, 'units': r'M$_\odot$',
+                                    'depends_on': transforms.logsfr_ratios_to_masses_psb}
+# This gives the start and stop of each age bin.  The fixed bins can/should be adjusted and its
+# length must match the lenth of "mass"
+agelims = np.array([1, 0.2*1e9] + \
+        np.linspace((0.3+.1)*1e9, 2e9, 5).tolist() \
+        + np.linspace(2e9, 13.6e9, 4)[1:].tolist())
+_nonpar_continuity_psb_["agebins"]    = {'N': 9, 'isfree': False,
+                                          'depends_on': transforms.psb_logsfr_ratios_to_agebins,
+                                          'init': np.array([np.log10(agelims[:-1]), np.log10(agelims[1:])]).T,
+                                          'units': 'log(yr)'}
+
+TemplateLibrary["continuity_psb_sfh"] = (_nonpar_continuity_psb_,
+                                          ("Non-parameteric SFH fitting for mass in Nfixed fixed bins "
+                                           "and Nflex flexible time bins with a smoothness prior"))                                           
 
 # ----------------------------
 # --- Dirichlet SFH ----

--- a/prospect/models/transforms.py
+++ b/prospect/models/transforms.py
@@ -266,7 +266,7 @@ def logsfr_ratios_to_masses_psb(logmass=None, logsfr_ratios=None,
     mold = mbin * old_factor 
     n_masses = np.full(nflex, mbin)
 
-    return np.array([myoung] + n_masses.tolist() + mold.tolist())
+    return np.array(myoung.tolist() + n_masses.tolist() + mold.tolist())
 
 def psb_logsfr_ratios_to_agebins(logsfr_ratios=None, agebins=None, 
                                tlast=None, tflex=None, nflex=None, nfixed=None, **extras):

--- a/prospect/models/transforms.py
+++ b/prospect/models/transforms.py
@@ -226,6 +226,89 @@ def logsfr_ratios_to_agebins(logsfr_ratios=None, agebins=None, **extras):
     agebins = np.log10([agelims[:-1], agelims[1:]]).T
 
     return agebins
+    
+# --------------------------------------
+# -- Transforms for the fixed+flexible non-parametric SFHs used in (Suess et al. 2021) --
+# --------------------------------------    
+def logsfr_ratios_to_masses_psb(logmass=None, logsfr_ratios=None,
+                                 logsfr_ratio_young=None, logsfr_ratio_old=None,
+                                 tlast=None, tflex=None, nflex=None, nfixed=None, 
+                                 agebins=None, **extras):
+    """This is a modified version of logsfr_ratios_to_masses_flex above. This now
+    assumes that there are nfixed fixed-edge timebins at the beginning of 
+    the universe, followed by nflex flexible timebins that each form an equal
+    stellar mass. The final bin has variable width and variable SFR; the width
+    of the bin is set by the parameter tlast.
+                                 
+    The major difference between this and the transform above is that 
+    logsfr_ratio_old is a vector.                             
+    """
+                                     
+    # clip for numerical stability
+    nflex = nflex[0]; nfixed = nfixed[0]
+    logsfr_ratio_young = np.clip(logsfr_ratio_young[0], -7, 7)
+    logsfr_ratio_old = np.clip(logsfr_ratio_old, -7, 7)
+    syoung, sold = 10**logsfr_ratio_young, 10**logsfr_ratio_old
+    sratios = 10.**np.clip(logsfr_ratios, -7, 7) # numerical issues...
+
+    # get agebins
+    abins = psb_logsfr_ratios_to_agebins(logsfr_ratios=logsfr_ratios,
+            agebins=agebins, tlast=tlast, tflex=tflex, nflex=nflex, nfixed=nfixed, **extras)     
+    
+    # get find mass in each bin
+    dtyoung, dt1 = (10**abins[:2, 1] - 10**abins[:2, 0])
+    dtold = 10**abins[-nfixed-1:, 1] - 10**abins[-nfixed-1:, 0]
+    old_factor = np.zeros(nfixed)
+    for i in range(nfixed): 
+        old_factor[i] = (1. / np.prod(sold[:i+1]) * np.prod(dtold[1:i+2]) / np.prod(dtold[:i+1]))                    
+    mbin = 10**logmass / (syoung*dtyoung/dt1 + np.sum(old_factor) + nflex)
+    myoung = syoung * mbin * dtyoung / dt1
+    mold = mbin * old_factor 
+    n_masses = np.full(nflex, mbin)
+
+    return np.array([myoung] + n_masses.tolist() + mold.tolist())
+
+def psb_logsfr_ratios_to_agebins(logsfr_ratios=None, agebins=None, 
+                               tlast=None, tflex=None, nflex=None, nfixed=None, **extras):
+    """This is a modified version of logsfr_ratios_to_agebins above. This now
+    assumes that there are nfixed fixed-edge timebins at the beginning of 
+    the universe, followed by nflex flexible timebins that each form an equal
+    stellar mass. The final bin has variable width and variable SFR; the width
+    of the bin is set by the parameter tlast.
+                               
+    For the flexible bins, we again use the equation:
+        delta(t1) = tuniv  / (1 + SUM(n=1 to n=nbins-1) PROD(j=1 to j=n) Sn)
+        where Sn = SFR(n) / SFR(n+1) and delta(t1) is width of youngest bin
+        
+    """
+
+    # dumb way to de-arrayify values...
+    tlast = tlast[0]; tflex = tflex[0]
+    try: nflex = nflex[0]
+    except IndexError: pass
+    try: nfixed = nfixed[0]
+    except IndexError: pass   
+                           
+    # numerical stability
+    logsfr_ratios = np.clip(logsfr_ratios, -7, 7)
+    
+    # flexible time is t_flex - youngest bin (= tlast, which we fit for)
+    # this is also equal to tuniv - upper_time - lower_time
+    tf = (tflex - tlast) * 1e9
+    
+    # figure out other bin sizes
+    n_ratio = logsfr_ratios.shape[0]
+    sfr_ratios = 10**logsfr_ratios
+    dt1 = tf / (1 + np.sum([np.prod(sfr_ratios[:(i+1)]) for i in range(n_ratio)]))
+
+    # translate into agelims vector (time bin edges)
+    agelims = [1, (tlast*1e9), dt1+(tlast*1e9)]
+    for i in range(n_ratio):
+        agelims += [dt1*np.prod(sfr_ratios[:(i+1)]) + agelims[-1]]
+    agelims += list(10**agebins[-nfixed:,1]) 
+    abins = np.log10([agelims[:-1], agelims[1:]]).T
+
+    return abins
 
 # --------------------------------------
 # --- Transforms for Dirichlet non-parametric SFH used in (Leja et al. 2017) ---


### PR DESCRIPTION
- add new SFH template ("continuity_psb_sfh") and associated transforms. This SFH is the SQuIGGLE model, described in detail in Suess+21. It is a modified version of continuity_flex_sfh which includes Nfixed fixed old bins, Nflex flexible bins, then one young bin with variable width. The last bin in particular makes this SFH a good choice for determining quenching timescales.
- add a check to the main likelihood function to ensure that the agebin spacing is >=1Myr. This ensures that flexible-bin models will not cause FSPS to crash with "agebins must be increasing" error message. This can happen during early likelihood calls for continuity_psb_sfh and continuity_flex_sfh if the prior on logsfr_ratios is broad.