### PR TITLE
Add another exception for defining info

### DIFF
--- a/prospect/models/templates.py
+++ b/prospect/models/templates.py
@@ -283,6 +283,9 @@ try:
                      delimiter=',')
 except OSError:
     info = {'name':[]}
+except TypeError:
+    # SPS_HOME not defined
+    info = {'name':[]}
 
 # Fit all lines by default
 elines_to_fit = {'N': 1, 'isfree': False, 'init': np.array(info['name'])}


### PR DESCRIPTION
Handle exception when SPS_HOME env variable not set.

The `info = np.genfromtxt(os.path.join(SPS_HOME, 'data', 'emlines_info.dat')` line raises a `TypeError` when the `$SPS_HOME` variable is not set and thus `SPS_HOME = os.getenv('SPS_HOME') = None`.