### PR TITLE
fixing suspected typo in sfh.py

### DIFF
--- a/prospect/plotting/sfh.py
+++ b/prospect/plotting/sfh.py
@@ -151,7 +151,7 @@ def parametric_cmf(times=None, tage=1., **sfh):
     if times is None:
         times = np.array(sfh["tage"])
 
-    pset = parametric_pset(tage=tage**sfh)
+    pset = parametric_pset(tage=tage, **sfh)
     _, mass = compute_mass_formed(tage - times, pset)
     return mass
 


### PR DESCRIPTION
edit in `parametric_cmf()` function: changing the `parametric_pset()` function call to remove a typo in argument from `(tage=tage**sfh)` to `(tage = tage, **sfh)` 