### PR TITLE
Avoid RuntimeWarning when smoothing with 0 km/s

### DIFF
--- a/prospect/utils/smoothing.py
+++ b/prospect/utils/smoothing.py
@@ -102,8 +102,12 @@ def smoothspec(wave, spec, resolution=None, outwave=None,
         units = 'km/s'
         sigma = resolution
         fwhm = sigma * sigma_to_fwhm
-        Rsigma = ckms / sigma
-        R = ckms / fwhm
+        if sigma == 0.0:
+            Rsigma = np.infty
+            R = np.infty
+        else:
+            Rsigma = ckms / sigma
+            R = ckms / fwhm
         width = Rsigma
         assert np.size(sigma) == 1, "`resolution` must be scalar for `smoothtype`='vel'"
 


### PR DESCRIPTION
Currently, running `smoothspec` with `sigma` set to zero yields a non-fatal `RuntimeWarning` due to the division by zero encountered in [these two lines](https://github.com/bd-j/prospector/blob/b0d86996d8a5055e6c501258abb5a8e03d9f9891/prospect/utils/smoothing.py#L105-L106) in `smoothspec`.

While the division doesn't actually cause issues with the output spectrum (i.e. the input spectrum is returned if `sigma` is set to zero, albeit interpolated to a new wavelength grid if one is provided), this pull request adds conditional logic that sets `R` and `Rsigma` to `np.infty` in this situation to avoid that division from taking place, and thus avoid the `RuntimeWarning` from being issued.