### PR TITLE
Stochastic SFH prior

### DIFF
--- a/prospect/models/priors.py
+++ b/prospect/models/priors.py
@@ -5,16 +5,13 @@
 When called these return the ln-prior-probability, and they can also be used to
 construct prior transforms (for nested sampling) and can be sampled from.
 """
+
 import numpy as np
 import scipy.stats
-from scipy.special import erf, erfinv
 
-__all__ = ["Prior", "Uniform", "TopHat", "Normal", "ClippedNormal",
+__all__ = ["Prior", "Uniform", "TopHat", "Normal", "MultiVariateNormal", "ClippedNormal",
            "LogNormal", "LogUniform", "Beta",
-           "StudentT", "SkewNormal",
-           "FastUniform", "FastTruncatedNormal",
-           "FastTruncatedEvenStudentTFreeDeg2",
-           "FastTruncatedEvenStudentTFreeDeg2Scalar"]
+           "StudentT", "SkewNormal"]
 
 
 class Prior(object):
@@ -38,7 +35,7 @@ class Prior(object):
         A list of names of the parameters, used to alias the intrinsic
         parameter names.  This way different instances of the same Prior can
         have different parameter names, in case they are being fit for....
-
+    
     Attributes
     ----------
     params : dictionary
@@ -106,18 +103,22 @@ class Prior(object):
         """
         if len(kwargs) > 0:
             self.update(**kwargs)
+            
         pdf = self.distribution.pdf
+        
         try:
             p = pdf(x, *self.args, loc=self.loc, scale=self.scale)
-        except(ValueError):
+            
+        except(ValueError):#, TypeError):
             # Deal with `x` vectors of shape (nsamples, len(prior))
             # for pdfs that don't broadcast nicely.
             p = [pdf(_x, *self.args, loc=self.loc, scale=self.scale)
-                 for _x in x]
+                 for _x in x]           
             p = np.array(p)
 
         with np.errstate(invalid='ignore'):
             lnp = np.log(p)
+            
         return lnp
 
     def sample(self, nsample=None, **kwargs):
@@ -258,6 +259,64 @@ class Normal(Prior):
         #if len(kwargs) > 0:
         #    self.update(**kwargs)
         return (-np.inf, np.inf)
+
+
+class MultiVariateNormal(Prior):
+    prior_params = ["mean", 'Sigma']
+    distribution = scipy.stats.norm
+
+    @property
+    def scale(self):
+        return self.params['Sigma']
+
+    @property
+    def loc(self):
+        return self.params['mean']
+
+    @property
+    def range(self):
+        nsig = 4
+        return (self.params['mean'] - nsig * self.params['Sigma'],
+                self.params['mean'] + nsig * self.params['Sigma'])
+
+    def bounds(self, **kwargs):
+        #if len(kwargs) > 0:
+        #    self.update(**kwargs)
+        return (-np.inf, np.inf)
+    
+    def sample(self, nsample=None, **kwargs):
+        prior = scipy.stats.multivariate_normal(mean=self.loc, cov=self.scale)
+        return prior.rvs(size = nsample)
+
+    def unit_transform(self, x, **kwargs):
+        """Go from a value of the CDF (between 0 and 1) to the corresponding
+        parameter value.
+
+        :param x:
+            A scalar or vector of same length as the Prior with values between
+            zero and one corresponding to the value of the CDF.
+
+        :returns theta:
+            The parameter value corresponding to the value of the CDF given by
+            `x`.
+        """
+        if len(kwargs) > 0:
+            self.update(**kwargs)
+        z = self.distribution.ppf(x, *self.args, loc=0, scale=1)
+        #print(z)
+        sqrtS = np.linalg.cholesky(self.params['Sigma']) #, lower=True)
+        #print(sqrtS)
+        #theta = np.matmul(z, sqrtS)
+        theta = np.matmul(sqrtS, z)
+        return theta
+    
+    def inverse_unit_transform(self, x, **kwargs):
+        """Go from the parameter value to the unit coordinate using the cdf.
+        """
+        if len(kwargs) > 0:
+            self.update(**kwargs)
+        return scipy.stats.multivariate_normal.cdf(x, *self.args,
+                                                   mean=0., cov=self.params['Sigma'])
 
 
 class ClippedNormal(Prior):
@@ -522,253 +581,3 @@ class StudentT(Prior):
 
     def bounds(self, **kwargs):
         return (-np.inf, np.inf)
-
-# fast versions to the above priors
-# essentially rewriting the numpy/scipy functions
-
-# A faster uniform distribution. Give it a lower bound `a` and
-# an upper bound `b`.
-class FastUniform(Prior):
-
-    prior_params = ['a', 'b']
-
-    def __init__(self, a=0.0, b=1.0, parnames=[], name='', ):
-        if len(parnames) == 0:
-            parnames = self.prior_params
-        assert len(parnames) == len(self.prior_params)
-
-        self.alias = dict(zip(self.prior_params, parnames))
-        self.params = {}
-
-        self.name = name
-
-        self.a, self.b = a, b
-
-        if self.b <= self.a:
-            raise ValueError('b must be greater than a')
-
-        self.diffthing = b - a
-        self.pdfval = 1.0 / (b - a)
-        self.logpdfval = np.log(self.pdfval)
-
-    def __len__(self):
-        return 1
-
-    def __call__(self, x):
-        if not hasattr(x, "__len__"):
-            if self.a <= x <= self.b:
-                return self.logpdfval
-            else:
-                return np.NINF
-        else:
-            return [self.logpdfval if (self.a <= xi <= self.b) else np.NINF for xi in x]
-
-    def scale(self):
-        return 0.5 * self.diffthing
-
-    def loc(self):
-        return 0.5 * (self.a + self.b)
-
-    def unit_transform(self, x):
-        return (x * self.diffthing) + self.a
-
-    def sample(self):
-        return self.unit_transform(np.random.rand())
-
-
-# A faster truncated normal distribution. Give it a lower bound `a`,
-# a upper bound `b`, a mean `mu`, and a standard deviation `sig`.
-class FastTruncatedNormal(Prior):
-
-    prior_params = ['a', 'b', 'mu', 'sig']
-
-    def __init__(self, a=-1.0, b=1.0, mu=0.0, sig=1.0, parnames=[], name='', ):
-        if len(parnames) == 0:
-            parnames = self.prior_params
-        assert len(parnames) == len(self.prior_params)
-
-        self.alias = dict(zip(self.prior_params, parnames))
-        self.params = {}
-
-        self.name = name
-
-        self.a, self.b, self.mu, self.sig = a, b, mu, sig
-
-        if self.b <= self.a:
-            raise ValueError('b must be greater than a')
-
-        self.alpha = (self.a - self.mu) / self.sig
-        self.beta = (self.b - self.mu) / self.sig
-
-        self.A = erf(self.alpha / np.sqrt(2.0))
-        self.B = erf(self.beta / np.sqrt(2.0))
-
-    def xi(self, x):
-        return (x - self.mu) / self.sig
-
-    def phi(self, x):
-        return np.sqrt(2.0 / (self.sig**2.0 * np.pi)) * np.exp(-0.5 * self.xi(x)**2.0)
-
-    def __len__(self):
-        return 1
-
-    def __call__(self, x):
-        # if self.a <= x <= self.b:
-        #     return np.log(self.phi(x) / (self.B - self.A))
-        # else:
-        #     return np.NINF
-        if not hasattr(x, "__len__"):
-            if self.a <= x <= self.b:
-                return np.log(self.phi(x) / (self.B - self.A))
-            else:
-                np.NINF
-        else:
-            return [np.log(self.phi(xi) / (self.B - self.A)) if (self.a <= xi <= self.b) else np.NINF for xi in x]
-
-    def scale(self):
-        return self.sig
-
-    def loc(self):
-        return self.mu
-
-    def unit_transform(self, x):
-        return self.sig * np.sqrt(2.0) * erfinv((self.B - self.A) * x + self.A) + self.mu
-
-    def sample(self):
-        return self.unit_transform(np.random.rand())
-
-
-# Okay. This is a sort of Student's t-distribution that allows
-# for truncation and rescaling, but it requires nu = 2 and mu = 0
-# and for the truncation limits to be equidistant from mu. Give it
-# the half-width of truncation (i.e. if you want it truncated to the
-# domain (-5, 5), give it `hw = 5`) and the rescaled standard
-# devation `sig`.
-class FastTruncatedEvenStudentTFreeDeg2(Prior):
-
-    prior_params = ['hw', 'sig']
-
-    def __init__(self, hw=0.0, sig=1.0, parnames=[], name='', ):
-        if len(parnames) == 0:
-            parnames = self.prior_params
-        assert len(parnames) == len(self.prior_params)
-
-        self.alias = dict(zip(self.prior_params, parnames))
-        self.params = {}
-
-        self.name = name
-
-        self.hw, self.sig = hw, sig
-
-        if np.any(self.hw <= 0.0):
-            raise ValueError('hw must be greater than 0.0')
-
-        if np.any(self.sig <= 0.0):
-            raise ValueError('sig must be greater than 0.0')
-
-        self.const1 = np.sqrt(1.0 + 0.5*(self.hw**2.0))
-        self.const2 = 2.0 * self.sig * self.hw
-        self.const3 = self.const2**2.0
-        self.const4 = 2.0 * (self.hw**2.0)
-
-    def __len__(self):
-        return len(self.hw)
-
-    def __call__(self, x):
-        if not hasattr(x, "__len__"):
-            if np.abs(x) <= self.hw:
-                return np.log(self.const1 / (self.const2 * (1 + 0.5*(x / self.sig)**2.0)**1.5))
-            else:
-                return np.NINF
-        else:
-            ret = np.log(self.const1 / (self.const2 * (1 + 0.5*(x / self.sig)**2.0)**1.5))
-            bad = np.abs(x) > self.hw
-            ret[bad] = np.NINF
-            return ret
-
-    def scale(self):
-        return self.sig
-
-    def loc(self):
-        return 0.0
-
-    def invcdf_numerator(self, x):
-        return -1.0 * (self.const3 * x**2.0 - self.const3 * x + (self.sig * self.hw)**2.0)
-
-    def invcdf_denominator(self, x):
-        return self.const4 * x**2.0 - self.const4 * x - self.sig**2.0
-
-    def unit_transform(self, x):
-        f = (((x > 0.5) & (x <= 1.0)) * np.sqrt(self.invcdf_numerator(x) / self.invcdf_denominator(x)) -
-             ((x >= 0.0) & (x <= 0.5)) * np.sqrt(self.invcdf_numerator(x) / self.invcdf_denominator(x)))
-        return f
-
-    def sample(self):
-        return self.unit_transform(np.random.rand())
-
-
-# Okay. This is a sort of Student's t-distribution that allows
-# for truncation and rescaling, but it requires nu = 2 and mu = 0
-# and for the truncation limits to be equidistant from mu. Give it
-# the half-width of truncation (i.e. if you want it truncated to the
-# domain (-5, 5), give it `hw = 5`) and the rescaled standard
-# devation `sig`.
-class FastTruncatedEvenStudentTFreeDeg2Scalar(Prior):
-
-    prior_params = ['hw', 'sig']
-
-    def __init__(self, hw=0.0, sig=1.0, parnames=[], name='', ):
-        if len(parnames) == 0:
-            parnames = self.prior_params
-        assert len(parnames) == len(self.prior_params)
-
-        self.alias = dict(zip(self.prior_params, parnames))
-        self.params = {}
-
-        self.name = name
-
-        self.hw, self.sig = hw, sig
-
-        if self.hw <= 0.0:
-            raise ValueError('hw must be greater than 0.0')
-
-        if self.sig <= 0.0:
-            raise ValueError('sig must be greater than 0.0')
-
-        self.const1 = np.sqrt(1.0 + 0.5*(self.hw**2.0))
-        self.const2 = 2.0 * self.sig * self.hw
-        self.const3 = self.const2**2.0
-        self.const4 = 2.0 * (self.hw**2.0)
-
-    def __len__(self):
-        return 1
-
-    def __call__(self, x):
-        if not hasattr(x, "__len__"):
-            if np.abs(x) <= self.hw:
-                return np.log(self.const1 / (self.const2 * (1 + 0.5*(x / self.sig)**2.0)**1.5))
-            else:
-                return np.NINF
-        else:
-            return [np.log(self.const1 / (self.const2 * (1 + 0.5*(xi / self.sig)**2.0)**1.5)) if np.abs(xi) <= self.hw else np.NINF for xi in x]
-
-    def scale(self):
-        return self.sig
-
-    def loc(self):
-        return 0.0
-
-    def invcdf_numerator(self, x):
-        return -1.0 * (self.const3 * x**2.0 - self.const3 * x + (self.sig * self.hw)**2.0)
-
-    def invcdf_denominator(self, x):
-        return self.const4 * x**2.0 - self.const4 * x - self.sig**2.0
-
-    def unit_transform(self, x):
-        if 0.0 <= x <= 0.5:
-            return -1.0 * np.sqrt(self.invcdf_numerator(x) / self.invcdf_denominator(x))
-        elif 0.5 < x <= 1.0:
-            return np.sqrt(self.invcdf_numerator(x) / self.invcdf_denominator(x))
-
-    def sample(self):
-        return self.unit_transform(np.random.rand())

--- a/prospect/models/priors.py
+++ b/prospect/models/priors.py
@@ -8,10 +8,15 @@ construct prior transforms (for nested sampling) and can be sampled from.
 
 import numpy as np
 import scipy.stats
+from scipy.special import erf, erfinv
+
 
 __all__ = ["Prior", "Uniform", "TopHat", "Normal", "MultiVariateNormal", "ClippedNormal",
            "LogNormal", "LogUniform", "Beta",
-           "StudentT", "SkewNormal"]
+           "StudentT", "SkewNormal",
+           "FastUniform", "FastTruncatedNormal",
+           "FastTruncatedEvenStudentTFreeDeg2",
+           "FastTruncatedEvenStudentTFreeDeg2Scalar"]
 
 
 class Prior(object):
@@ -581,3 +586,254 @@ class StudentT(Prior):
 
     def bounds(self, **kwargs):
         return (-np.inf, np.inf)
+
+
+# fast versions to the above priors
+# essentially rewriting the numpy/scipy functions
+
+# A faster uniform distribution. Give it a lower bound `a` and
+# an upper bound `b`.
+class FastUniform(Prior):
+
+    prior_params = ['a', 'b']
+
+    def __init__(self, a=0.0, b=1.0, parnames=[], name='', ):
+        if len(parnames) == 0:
+            parnames = self.prior_params
+        assert len(parnames) == len(self.prior_params)
+
+        self.alias = dict(zip(self.prior_params, parnames))
+        self.params = {}
+
+        self.name = name
+
+        self.a, self.b = a, b
+
+        if self.b <= self.a:
+            raise ValueError('b must be greater than a')
+
+        self.diffthing = b - a
+        self.pdfval = 1.0 / (b - a)
+        self.logpdfval = np.log(self.pdfval)
+
+    def __len__(self):
+        return 1
+
+    def __call__(self, x):
+        if not hasattr(x, "__len__"):
+            if self.a <= x <= self.b:
+                return self.logpdfval
+            else:
+                return np.NINF
+        else:
+            return [self.logpdfval if (self.a <= xi <= self.b) else np.NINF for xi in x]
+
+    def scale(self):
+        return 0.5 * self.diffthing
+
+    def loc(self):
+        return 0.5 * (self.a + self.b)
+
+    def unit_transform(self, x):
+        return (x * self.diffthing) + self.a
+
+    def sample(self):
+        return self.unit_transform(np.random.rand())
+
+
+# A faster truncated normal distribution. Give it a lower bound `a`,
+# a upper bound `b`, a mean `mu`, and a standard deviation `sig`.
+class FastTruncatedNormal(Prior):
+
+    prior_params = ['a', 'b', 'mu', 'sig']
+
+    def __init__(self, a=-1.0, b=1.0, mu=0.0, sig=1.0, parnames=[], name='', ):
+        if len(parnames) == 0:
+            parnames = self.prior_params
+        assert len(parnames) == len(self.prior_params)
+
+        self.alias = dict(zip(self.prior_params, parnames))
+        self.params = {}
+
+        self.name = name
+
+        self.a, self.b, self.mu, self.sig = a, b, mu, sig
+
+        if self.b <= self.a:
+            raise ValueError('b must be greater than a')
+
+        self.alpha = (self.a - self.mu) / self.sig
+        self.beta = (self.b - self.mu) / self.sig
+
+        self.A = erf(self.alpha / np.sqrt(2.0))
+        self.B = erf(self.beta / np.sqrt(2.0))
+
+    def xi(self, x):
+        return (x - self.mu) / self.sig
+
+    def phi(self, x):
+        return np.sqrt(2.0 / (self.sig**2.0 * np.pi)) * np.exp(-0.5 * self.xi(x)**2.0)
+
+    def __len__(self):
+        return 1
+
+    def __call__(self, x):
+        # if self.a <= x <= self.b:
+        #     return np.log(self.phi(x) / (self.B - self.A))
+        # else:
+        #     return np.NINF
+        if not hasattr(x, "__len__"):
+            if self.a <= x <= self.b:
+                return np.log(self.phi(x) / (self.B - self.A))
+            else:
+                np.NINF
+        else:
+            return [np.log(self.phi(xi) / (self.B - self.A)) if (self.a <= xi <= self.b) else np.NINF for xi in x]
+
+    def scale(self):
+        return self.sig
+
+    def loc(self):
+        return self.mu
+
+    def unit_transform(self, x):
+        return self.sig * np.sqrt(2.0) * erfinv((self.B - self.A) * x + self.A) + self.mu
+
+    def sample(self):
+        return self.unit_transform(np.random.rand())
+
+
+# Okay. This is a sort of Student's t-distribution that allows
+# for truncation and rescaling, but it requires nu = 2 and mu = 0
+# and for the truncation limits to be equidistant from mu. Give it
+# the half-width of truncation (i.e. if you want it truncated to the
+# domain (-5, 5), give it `hw = 5`) and the rescaled standard
+# devation `sig`.
+class FastTruncatedEvenStudentTFreeDeg2(Prior):
+
+    prior_params = ['hw', 'sig']
+
+    def __init__(self, hw=0.0, sig=1.0, parnames=[], name='', ):
+        if len(parnames) == 0:
+            parnames = self.prior_params
+        assert len(parnames) == len(self.prior_params)
+
+        self.alias = dict(zip(self.prior_params, parnames))
+        self.params = {}
+
+        self.name = name
+
+        self.hw, self.sig = hw, sig
+
+        if np.any(self.hw <= 0.0):
+            raise ValueError('hw must be greater than 0.0')
+
+        if np.any(self.sig <= 0.0):
+            raise ValueError('sig must be greater than 0.0')
+
+        self.const1 = np.sqrt(1.0 + 0.5*(self.hw**2.0))
+        self.const2 = 2.0 * self.sig * self.hw
+        self.const3 = self.const2**2.0
+        self.const4 = 2.0 * (self.hw**2.0)
+
+    def __len__(self):
+        return len(self.hw)
+
+    def __call__(self, x):
+        if not hasattr(x, "__len__"):
+            if np.abs(x) <= self.hw:
+                return np.log(self.const1 / (self.const2 * (1 + 0.5*(x / self.sig)**2.0)**1.5))
+            else:
+                return np.NINF
+        else:
+            ret = np.log(self.const1 / (self.const2 * (1 + 0.5*(x / self.sig)**2.0)**1.5))
+            bad = np.abs(x) > self.hw
+            ret[bad] = np.NINF
+            return ret
+
+    def scale(self):
+        return self.sig
+
+    def loc(self):
+        return 0.0
+
+    def invcdf_numerator(self, x):
+        return -1.0 * (self.const3 * x**2.0 - self.const3 * x + (self.sig * self.hw)**2.0)
+
+    def invcdf_denominator(self, x):
+        return self.const4 * x**2.0 - self.const4 * x - self.sig**2.0
+
+    def unit_transform(self, x):
+        f = (((x > 0.5) & (x <= 1.0)) * np.sqrt(self.invcdf_numerator(x) / self.invcdf_denominator(x)) -
+             ((x >= 0.0) & (x <= 0.5)) * np.sqrt(self.invcdf_numerator(x) / self.invcdf_denominator(x)))
+        return f
+
+    def sample(self):
+        return self.unit_transform(np.random.rand())
+
+
+# Okay. This is a sort of Student's t-distribution that allows
+# for truncation and rescaling, but it requires nu = 2 and mu = 0
+# and for the truncation limits to be equidistant from mu. Give it
+# the half-width of truncation (i.e. if you want it truncated to the
+# domain (-5, 5), give it `hw = 5`) and the rescaled standard
+# devation `sig`.
+class FastTruncatedEvenStudentTFreeDeg2Scalar(Prior):
+
+    prior_params = ['hw', 'sig']
+
+    def __init__(self, hw=0.0, sig=1.0, parnames=[], name='', ):
+        if len(parnames) == 0:
+            parnames = self.prior_params
+        assert len(parnames) == len(self.prior_params)
+
+        self.alias = dict(zip(self.prior_params, parnames))
+        self.params = {}
+
+        self.name = name
+
+        self.hw, self.sig = hw, sig
+
+        if self.hw <= 0.0:
+            raise ValueError('hw must be greater than 0.0')
+
+        if self.sig <= 0.0:
+            raise ValueError('sig must be greater than 0.0')
+
+        self.const1 = np.sqrt(1.0 + 0.5*(self.hw**2.0))
+        self.const2 = 2.0 * self.sig * self.hw
+        self.const3 = self.const2**2.0
+        self.const4 = 2.0 * (self.hw**2.0)
+
+    def __len__(self):
+        return 1
+
+    def __call__(self, x):
+        if not hasattr(x, "__len__"):
+            if np.abs(x) <= self.hw:
+                return np.log(self.const1 / (self.const2 * (1 + 0.5*(x / self.sig)**2.0)**1.5))
+            else:
+                return np.NINF
+        else:
+            return [np.log(self.const1 / (self.const2 * (1 + 0.5*(xi / self.sig)**2.0)**1.5)) if np.abs(xi) <= self.hw else np.NINF for xi in x]
+
+    def scale(self):
+        return self.sig
+
+    def loc(self):
+        return 0.0
+
+    def invcdf_numerator(self, x):
+        return -1.0 * (self.const3 * x**2.0 - self.const3 * x + (self.sig * self.hw)**2.0)
+
+    def invcdf_denominator(self, x):
+        return self.const4 * x**2.0 - self.const4 * x - self.sig**2.0
+
+    def unit_transform(self, x):
+        if 0.0 <= x <= 0.5:
+            return -1.0 * np.sqrt(self.invcdf_numerator(x) / self.invcdf_denominator(x))
+        elif 0.5 < x <= 1.0:
+            return np.sqrt(self.invcdf_numerator(x) / self.invcdf_denominator(x))
+
+    def sample(self):
+        return self.unit_transform(np.random.rand())

--- a/prospect/models/templates.py
+++ b/prospect/models/templates.py
@@ -9,13 +9,13 @@ from copy import deepcopy
 import numpy as np
 import os
 from . import priors
-from . import priors_beta
 from . import transforms
 
 __all__ = ["TemplateLibrary",
            "describe",
            "adjust_dirichlet_agebins",
            "adjust_continuity_agebins",
+           "adjust_stochastic_params"
            ]
 
 
@@ -124,6 +124,27 @@ def adjust_continuity_agebins(parset, tuniv=13.7, nbins=7):
     parset['mass']['N'] = ncomp
     parset['agebins']['N'] = ncomp
     parset['agebins']['init'] = agebins.T
+    parset["logsfr_ratios"]["N"] = ncomp - 1
+    parset["logsfr_ratios"]["init"] = mean
+    parset["logsfr_ratios"]["prior"] = rprior
+
+    return parset
+
+
+def adjust_stochastic_params(parset, tuniv=13.7):
+    
+    agebins = parset['agebins']['init']
+    
+    ncomp = len(parset['agebins']['init'])
+    mean = np.zeros(ncomp - 1)
+    psd_params = [parset['sigma_reg']['init'], parset['tau_eq']['init'], parset['tau_in']['init'],
+                  parset['sigma_dyn']['init'], parset['tau_dyn']['init']]
+    sfr_covar = transforms.get_sfr_covar(psd_params, agebins=agebins)
+    sfr_ratio_covar = transforms.sfr_covar_to_sfr_ratio_covar(sfr_covar)
+    rprior = priors.MultiVariateNormal(mean=mean, Sigma=sfr_ratio_covar)
+    
+    parset['mass']['N'] = ncomp
+    parset['agebins']['N'] = ncomp
     parset["logsfr_ratios"]["N"] = ncomp - 1
     parset["logsfr_ratios"]["init"] = mean
     parset["logsfr_ratios"]["prior"] = rprior
@@ -283,9 +304,6 @@ try:
                      dtype=[('wave', 'f8'), ('name', '<U20')],
                      delimiter=',')
 except OSError:
-    info = {'name':[]}
-except TypeError:
-    # SPS_HOME not defined
     info = {'name':[]}
 
 # Fit all lines by default
@@ -659,6 +677,58 @@ _dirichlet_["total_mass"] = mass
 TemplateLibrary["dirichlet_sfh"] = (_dirichlet_,
                                     "Non-parameteric SFH with Dirichlet prior (fractional SFR)")
 
+
+# ----------------------------
+# --- Stochastic SFH ----
+# ----------------------------
+# A non-parametric SFH model which correlates the SFRs between time bins based on Extended Regulator model in TFC2020
+
+_stochastic_ = TemplateLibrary["ssp"]
+_ = _stochastic_.pop("tage")
+
+_stochastic_["sfh"] = {"N": 1, "isfree": False, "init": 3, "units": "FSPS index"}
+# This is the *total*  mass formed, as a variable
+_stochastic_["logmass"] = {"N": 1, "isfree": True, "init": 10, 'units': 'Msun',
+                           'prior': priors.TopHat(mini=7, maxi=12)}
+# This will be the mass in each bin.  It depends on other free and fixed
+# parameters.  Its length needs to be modified based on the number of bins
+_stochastic_["mass"] = {'N': 8, 'isfree': False, 'init': 1e6, 'units': r'M$_\odot$',
+                        'depends_on': transforms.logsfr_ratios_to_masses}
+
+# This gives the start and stop of each age bin.  It can be adjusted and its
+# length must match the lenth of "mass"
+agebins = [[0.0, 6.0], [6.0, 6.5], [6.5, 7.0], [7.0, 7.5], [7.5, 8.0], [8.0, 8.5], [8.5, 9.0], [9.5, 10.0]]
+_stochastic_["agebins"] = {'N': 8, 'isfree': False, 'init': agebins, 'units': 'log(yr)'}
+
+# Sets the PSD parameters & priors
+# sigma_reg: Overall stochasticity coming from gas inflow
+_stochastic_["sigma_reg"] = {'name': 'sigma_reg', 'N': 1, 'isfree': True, 'init': 0.3, 
+                             'prior': priors.LogUniform(mini=0.01, maxi=5.0), 'units': 'dex^2'}
+# tau_eq: Timescale associated with equilibrium gas cycling in gas reservoir (related to depletion timescale)
+_stochastic_["tau_eq"] = {'name': 'tau_eq', 'N': 1, 'isfree': True, 'init': 2.5, 
+                          'prior': priors.TopHat(mini=0.01, maxi=7.0), 'units': 'Gyr'}
+# tau_in: Characteristic timescale associated with gas inflow into gas reservoir
+_stochastic_["tau_in"] = {'name': 'tau_in', 'N': 1, 'isfree': False, 'init': 7.0, 'units': 'Gyr'}
+# sigma_dyn: Overall stochasticity coming from short-term, dynamical processes (e.g., creation/destruction of GMCs)
+_stochastic_["sigma_dyn"] = {'name': 'sigma_dyn', 'N': 1, 'isfree': True, 'init': 0.01, 
+                             'prior': priors.LogUniform(mini=0.001, maxi=0.1), 'units': 'dex^2'}
+# tau_dyn: Characteristic timescale associated with short-term, dynamical processes
+_stochastic_["tau_dyn"] = {'name': 'tau_dyn', 'N': 1, 'isfree': True, 'init': 0.025, 
+                           'prior': priors.ClippedNormal(mini=0.005, maxi=0.2, mean=0.01, sigma=0.02), 'units': 'Gyr'}
+
+# calculates covariance matrix from the initial PSD parameter values to be used in log SFR ratios prior
+psd_params = [0.3, 2.5, 1.0, 0.01, 0.025]
+sfr_covar = transforms.get_sfr_covar(psd_params, agebins=agebins)
+sfr_ratio_covar = transforms.sfr_covar_to_sfr_ratio_covar(sfr_covar)
+
+# This controls the distribution of SFR(t) / SFR(t+dt). It has NBINS-1 components.
+_stochastic_["logsfr_ratios"] = {'N': 7, 'isfree': True, 'init': [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                                 'prior': priors.MultiVariateNormal(mean=[0.]*7, Sigma=sfr_ratio_covar)}
+
+TemplateLibrary["stochastic_sfh"] = (_stochastic_,
+                                     "Stochastic SFH which correlates the SFRs between time bins based on model in TFC2020")
+
+
 # ----------------------------
 # --- Prospector-alpha ---
 # ----------------------------
@@ -694,46 +764,3 @@ _alpha_ = adjust_dirichlet_agebins(_alpha_, agelims=(np.log10(alpha_agelims) + 9
 
 TemplateLibrary["alpha"] = (_alpha_,
                             "The prospector-alpha model, Leja et al. 2017")
-
-
-# ----------------------------
-# --- Prospector-beta ---
-# ----------------------------
-
-_beta_nzsfh_ = TemplateLibrary["alpha"]
-_beta_nzsfh_.pop('z_fraction', None)
-_beta_nzsfh_.pop('total_mass', None)
-
-nbins_sfh = 7 # number of sfh bins
-_beta_nzsfh_['nzsfh'] = {'N': nbins_sfh+2, 'isfree': True, 'init': np.concatenate([[0.5,8,0.0], np.zeros(nbins_sfh-1)]),
-                         'prior': priors_beta.NzSFH(zred_mini=1e-3, zred_maxi=15.0,
-                                                    mass_mini=7.0, mass_maxi=12.5,
-                                                    z_mini=-1.98, z_maxi=0.19,
-                                                    logsfr_ratio_mini=-5.0, logsfr_ratio_maxi=5.0,
-                                                    logsfr_ratio_tscale=0.3, nbins_sfh=nbins_sfh,
-                                                    const_phi=True)}
-
-_beta_nzsfh_['zred'] = {'N': 1, 'isfree': False, 'init': 0.5,
-                        'depends_on': transforms.nzsfh_to_zred}
-
-_beta_nzsfh_['logmass'] = {'N': 1, 'isfree': False, 'init': 8.0, 'units': 'Msun',
-                           'depends_on': transforms.nzsfh_to_logmass}
-
-_beta_nzsfh_['logzsol'] = {'N': 1, 'isfree': False, 'init': -0.5, 'units': r'$\log (Z/Z_\odot)$',
-                           'depends_on': transforms.nzsfh_to_logzsol}
-
-# --- SFH ---
-_beta_nzsfh_["sfh"] = {'N': 1, 'isfree': False, 'init': 3}
-
-_beta_nzsfh_['logsfr_ratios'] = {'N': nbins_sfh-1, 'isfree': False, 'init': 0.0,
-                                 'depends_on': transforms.nzsfh_to_logsfr_ratios}
-
-_beta_nzsfh_["mass"] = {'N': nbins_sfh, 'isfree': False, 'init': 1e6, 'units': r'M$_\odot$',
-                        'depends_on': transforms.logsfr_ratios_to_masses}
-
-_beta_nzsfh_['agebins'] = {'N': nbins_sfh, 'isfree': False,
-                           'init': transforms.zred_to_agebins_pbeta(np.atleast_1d(0.5), np.zeros(nbins_sfh)),
-                           'depends_on': transforms.zred_to_agebins_pbeta}
-
-TemplateLibrary["beta"] = (_beta_nzsfh_,
-                           "The prospector-beta model; Wang, Leja, et al. 2023")

--- a/prospect/models/transforms.py
+++ b/prospect/models/transforms.py
@@ -10,6 +10,8 @@ They can be used as ``"depends_on"`` entries in parameter specifications.
 
 import numpy as np
 from ..sources.constants import cosmo
+from gp_sfh import *
+import gp_sfh_kernels
 
 __all__ = ["stellar_logzsol", "delogify_mass",
            "tburst_from_fage", "tage_from_tuniv", "zred_to_agebins",
@@ -17,10 +19,7 @@ __all__ = ["stellar_logzsol", "delogify_mass",
            "logsfr_ratios_to_masses", "logsfr_ratios_to_sfrs",
            "logsfr_ratios_to_masses_flex", "logsfr_ratios_to_agebins",
            "zfrac_to_masses", "zfrac_to_sfrac", "zfrac_to_sfr", "masses_to_zfrac",
-           "sfratio_to_sfr", "sfratio_to_mass",
-           "zred_to_agebins_pbeta",
-           "zredmassmet_to_zred", "zredmassmet_to_logmass", "zredmassmet_to_mass", "zredmassmet_to_logzsol",
-           "nzsfh_to_zred", "nzsfh_to_logmass", "nzsfh_to_mass", "nzsfh_to_logzsol", "nzsfh_to_logsfr_ratios"]
+           "sfratio_to_sfr", "sfratio_to_mass", "get_sfr_covar", "sfr_covar_to_sfr_ratio_covar"]
 
 
 # --------------------------------------
@@ -184,7 +183,7 @@ def logsfr_ratios_to_masses(logmass=None, logsfr_ratios=None, agebins=None,
     time.
     """
     nbins = agebins.shape[0]
-    sratios = 10**np.clip(logsfr_ratios, -10, 10)  # numerical issues...
+    sratios = 10**np.clip(logsfr_ratios, -100, 100)  # numerical issues...
     dt = (10**agebins[:, 1] - 10**agebins[:, 0])
     coeffs = np.array([ (1. / np.prod(sratios[:i])) * (np.prod(dt[1: i+1]) / np.prod(dt[: i]))
                         for i in range(nbins)])
@@ -209,8 +208,8 @@ def logsfr_ratios_to_sfrs(logmass=None, logsfr_ratios=None, agebins=None, **extr
 def logsfr_ratios_to_masses_flex(logmass=None, logsfr_ratios=None,
                                  logsfr_ratio_young=None, logsfr_ratio_old=None,
                                  **extras):
-    logsfr_ratio_young = np.clip(logsfr_ratio_young, -10, 10)
-    logsfr_ratio_old = np.clip(logsfr_ratio_old, -10, 10)
+    logsfr_ratio_young = np.clip(logsfr_ratio_young, -100, 100)
+    logsfr_ratio_old = np.clip(logsfr_ratio_old, -100, 100)
 
     abins = logsfr_ratios_to_agebins(logsfr_ratios=logsfr_ratios, **extras)
 
@@ -236,7 +235,7 @@ def logsfr_ratios_to_agebins(logsfr_ratios=None, agebins=None, **extras):
     """
 
     # numerical stability
-    logsfr_ratios = np.clip(logsfr_ratios, -10, 10)
+    logsfr_ratios = np.clip(logsfr_ratios, -100, 100)
 
     # calculate delta(t) for oldest, youngest bins (fixed)
     lower_time = (10**agebins[0, 1] - 10**agebins[0, 0])
@@ -490,68 +489,52 @@ def sfratio_to_sfr(sfr_ratio=None, sfr0=None, **extras):
 
 def sfratio_to_mass(sfr_ratio=None, sfr0=None, agebins=None, **extras):
     raise(NotImplementedError)
-
-
+    
+    
 # --------------------------------------
-# --- Transforms for prospector-beta ---
+# --- Transforms for stochastic SFH prior ---
 # --------------------------------------
 
-def zred_to_agebins_pbeta(zred=None, agebins=[], **extras):
-    """New agebin scheme, refined so that none of the bins is overly wide when the universe is young.
-
-    Parameters
-    ----------
-    zred : float
-        Cosmological redshift.  This sets the age of the universe.
-
-    agebins :  ndarray of shape ``(nbin, 2)``
-        The SFH bin edges in log10(years).
-
+def get_sfr_covar(psd_params, agebins=[], **extras):
+    
+    """
+    Caluclates SFR covariance matrix for a given set of PSD parameters and agebins
+    PSD parameters must be in the order: [sigma_reg, tau_eq, tau_in, sigma_dyn, tau_dyn]
+    
     Returns
     -------
-    agebins : ndarray of shape ``(nbin, 2)``
-        The new SFH bin edges.
+    covar_matrix: (Nbins, Nbins)-dim array of covariance values for SFR
     """
-    amin = 7.1295
-    nbins_sfh = len(agebins)
-    tuniv = cosmo.age(zred)[0].value*1e9 # because input zred is atleast_1d
-    tbinmax = (tuniv*0.9)
-    if (zred <= 3.):
-        agelims = [0.0,7.47712] + np.linspace(8.0,np.log10(tbinmax),nbins_sfh-2).tolist() + [np.log10(tuniv)]
-    else:
-        agelims = np.linspace(amin,np.log10(tbinmax),nbins_sfh).tolist() + [np.log10(tuniv)]
-        agelims[0] = 0
+    
+    bincenters = np.array([np.mean(agebins[i]) for i in range(len(agebins))])
+    bincenters = (10**bincenters)/1e9
+    case1 = simple_GP_sfh()
+    case1.tarr = bincenters
+    case1.kernel = gp_sfh_kernels.extended_regulator_model_kernel_paramlist
+    covar_matrix = case1.get_covariance_matrix(kernel_params = psd_params, show_prog=False)
+    
+    return covar_matrix
 
-    agebins = np.array([agelims[:-1], agelims[1:]])
-    return agebins.T
 
-# separates a theta vector of [zred, mass, met] into individual parameters
-# can be used with PhiMet & ZredMassMet
-def zredmassmet_to_zred(zredmassmet=None, **extras):
-    return zredmassmet[0]
-
-def zredmassmet_to_logmass(zredmassmet=None, **extras):
-    return zredmassmet[1]
-
-def zredmassmet_to_mass(zredmassmet=None, **extras):
-    return 10**zredmassmet[1]
-
-def zredmassmet_to_logzsol(zredmassmet=None, **extras):
-    return zredmassmet[2]
-
-# separates a theta vector of [zred, mass, met, logsfr_ratios] into individual parameters
-# can be used with PhiSFH & NzSFH
-def nzsfh_to_zred(nzsfh=None, **extras):
-    return nzsfh[0]
-
-def nzsfh_to_logmass(nzsfh=None, **extras):
-    return nzsfh[1]
-
-def nzsfh_to_mass(nzsfh=None, **extras):
-    return 10**nzsfh[1]
-
-def nzsfh_to_logzsol(nzsfh=None, **extras):
-    return nzsfh[2]
-
-def nzsfh_to_logsfr_ratios(nzsfh=None, **extras):
-    return nzsfh[3:]
+def sfr_covar_to_sfr_ratio_covar(covar_matrix):
+    
+    """
+    Caluclates log SFR ratio covariance matrix from SFR covariance matrix
+    
+    Returns
+    -------
+    sfr_ratio_covar: (Nbins-1, Nbins-1)-dim array of covariance values for log SFR
+    """
+    
+    dim = covar_matrix.shape[0]
+    
+    sfr_ratio_covar = []
+    
+    for i in range(dim-1):
+        row = []
+        for j in range(dim-1):
+            cov = covar_matrix[i][j] - covar_matrix[i+1][j] - covar_matrix[i][j+1] + covar_matrix[i+1][j+1]
+            row.append(cov)
+        sfr_ratio_covar.append(row)
+    
+    return np.array(sfr_ratio_covar)


### PR DESCRIPTION
Stochastic SFH prior -- adapted from the Extended Regulator model developed in [Caplar & Tacchella (2019)](https://ui.adsabs.harvard.edu/abs/2019MNRAS.487.3845C/abstract) and [Tacchella, Forbes & Caplar (2020)](https://ui.adsabs.harvard.edu/abs/2020MNRAS.497..698T/abstract), in conjunction with the GP implementation of [Iyer  & Speagle et al. (2024)](https://ui.adsabs.harvard.edu/abs/2024ApJ...961...53I/abstract), into a physically-motivated prior for non-parametric SFHs. Requires `gp_sfh.py` and `gp_sfh_kernels.py` from Kartheik Iyer's [GP-SFH module](https://github.com/kartheikiyer/GP-SFH). 
