### PR TITLE
Add a check for emission line names in fsps cloudy table

### DIFF
--- a/prospect/models/sedmodel.py
+++ b/prospect/models/sedmodel.py
@@ -406,6 +406,8 @@ class SpecModel(ProspectorParams):
             # unless some are explicitly fixed
             lnames_to_fit = self.params.get('elines_to_fit', all_lines)
             lnames_to_fix = self.params.get('elines_to_fix', np.array([]))
+            assert np.all(np.isin(lnames_to_fit, all_lines)), f"Some lines to fit ({lnames_to_fit})are not in the cloudy grid; see $SPS_HOME/data/emlines_info.dat for accepted names"
+            assert np.all(np.isin(lnames_to_fix, all_lines)), f"Some fixed lines ({lnames_to_fix}) are not in the cloudy grid; see $SPS_HOME/data/emlines_info.dat for accepted names"
             self._fit_eline = np.isin(all_lines, lnames_to_fit) & ~np.isin(all_lines, lnames_to_fix)
         else:
             self._fit_eline = np.zeros(len(all_lines), dtype=bool)
@@ -413,6 +415,8 @@ class SpecModel(ProspectorParams):
         self._fix_eline = ~self._fit_eline
 
         if self.params.get("elines_to_ignore", []):
+            assert np.all(np.isin(self.params["elines_to_ignore"], self.emline_info["name"])), f"Some ignored lines lines ({self.params['elines_to_ignore']}) are not in the cloudy grid; see $SPS_HOME/data/emlines_info.dat for accepted names"
+
             self._use_eline = ~np.isin(self.emline_info["name"],
                                        self.params["elines_to_ignore"])
 


### PR DESCRIPTION
Since the FSPS cloudy table of emission lines changed some line names, this PR adds checks to ensure that user supplied line names are in the table.