### PR TITLE
Obs cal

### DIFF
--- a/doc/dataformat.rst
+++ b/doc/dataformat.rst
@@ -79,7 +79,7 @@ For a single observation, you might do something like:
 .. code-block:: python
 
         def build_obs(N):
-            from prospect.data import Spectrum
+            from prospect.observation import Spectrum
             N = 1000  # number of wavelength points
             spec = Spectrum(wavelength=np.linspace(3000, 5000, N), flux=np.zeros(N), uncertainty=np.ones(N))
             # ensure that this is a valid observation for fitting
@@ -95,7 +95,7 @@ For photometry this might look like:
 .. code-block:: python
 
         def build_obs(N):
-            from prospect.data import Photometry
+            from prospect.observation import Photometry
             # valid sedpy filter names
             fnames = list([f"sdss_{b}0" for b in "ugriz"])
             Nf = len(fnames)
@@ -113,7 +113,7 @@ A tool exists to convert old combined observation dictionaries to a list of
 
 .. code-block:: python
 
-        from prospect.data import from_oldstyle
+        from prospect.observation import from_oldstyle
         # dummy observation dictionary with just a spectrum
         N = 1000
         obs = dict(wavelength=np.linspace(3000, 5000, N), spectrum=np.zeros(N), unc=np.ones(N),
@@ -129,7 +129,7 @@ The :py:meth:`build_obs` function
 
 The :py:meth:`build_obs` function in the parameter file is written by the user.
 It should take a dictionary of command line arguments as keyword arguments. It
-should return a list of :py:class:`prospect.data.Observation` instances,
+should return a list of :py:class:`prospect.observation.Observation` instances,
 described above.
 
 Other than that, the contents can be anything. Within this function you might
@@ -142,7 +142,7 @@ The point of this function is that you don't have to *externally* convert your
 data format to be what |Codename| expects and keep another version of files
 lying around: the conversion happens *within* the code itself. Again, the only
 requirement is that the function can take a ``run_params`` dictionary as keyword
-arguments and that it return :py:class:`prospect.data.Observation` instances, as
+arguments and that it return :py:class:`prospect.observation.Observation` instances, as
  described above.  Each observation instance should correspond to a particular
  dataset (e.g. a broadband photomtric SED, the spectrum from a particular
  instrument, or the spectrum from a particular night) that shares instrumental

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -40,49 +40,6 @@ sampling algorithm being used, and the kind of data that you have.  Hours or
 even days per fit is not uncommon for more complex models.
 
 
-Can I fit my spectrum too?
---------------------------
-There are several extra considerations that come up when fitting spectroscopy
-
-   1) Wavelength range and resolution.
-      Prospector is based on FSPS, which uses the MILES spectral library. These
-      have a resolution of ~2.5A FWHM from 3750AA - 7200AA restframe, and much
-      lower (R~200 or so, but not actually well defined) outside this range.
-      Higher resolution data (after including both velocity dispersion and
-      instrumental resolution) or spectral points outside this range cannot yet
-      be fit.
-
-   2) Relatedly, line spread function.
-      Prospector includes methods for FFT based smoothing of the spectra,
-      assuming a gaussian LSF (in either wavelength or velocity space). There is
-      also the possibility of FFT based smoothing for wavelength dependent
-      Gaussian dispersion (i.e. sigma_lambda = f(lambda) with f possibly a
-      polynomial of lambda). In practice the smoothed spectra will be a
-      combination of the library resolution plus whatever FFT smoothing is
-      applied. Hopefully this can be made to match your actual data resolution,
-      which is a combination of the physical velocity dispersion and the
-      instrumental resolution. The smoothing is controlled by the parameters
-      `sigma_smooth`, `smooth_type`, and `fftsmooth`
-
-   3) Nebular emission.
-      While prospector/FSPS include self-consistent nebular emission, the
-      treatment is probably not flexible enough at the moment to fit high S/N,
-      high resolution data including nebular emission (e.g. due to deviations of
-      line ratios from Cloudy predictions or to complicated gas kinematics that
-      are different than stellar kinematics). Thus fitting nebular lines should
-      take adavantage of the nebular line amplitude optimization/marginalization
-      capabilities. For very low resolution data this is less of an issue.
-
-   4) Spectrophotometric calibration.
-      There are various options for dealing with the spectral continuum shape
-      depending on how well you think your spectra are calibrated and if you
-      also fit photometry to tie down the continuum shape. You can optimize out
-      a polynomial "calibration" vector, or simultaneously fit for a polynomial
-      and marginalize over the polynomial coefficients (this allows you to place
-      priors on the accuracy of the spectrophotometric calibration). Or you can
-      just take the spectrum as perfectly calibrated.
-
-
 How do I fit for redshift as well as other parameters?
 ------------------------------------------------------
 The simplest way is to just let the parameter specification for ``"zred"``

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -30,6 +30,7 @@ Prospector allows you to:
    installation
    usage
    dataformat
+   spectra
    models
    sfhs
    nebular

--- a/doc/spectra.rst
+++ b/doc/spectra.rst
@@ -14,14 +14,18 @@ velocity dispersion and instrumental resolution) or spectral points outside this
 range cannot yet be fit.
 
 Prospector includes methods for FFT based smoothing of the spectra, assuming a
-gaussian LSF (in either wavelength or velocity space). There is also the
+Gaussian LSF (in either wavelength or velocity space). There is also the
 possibility of FFT based smoothing for wavelength dependent Gaussian dispersion
 (i.e. sigma_lambda = f(lambda) with f possibly a polynomial of lambda). In
-practice the smoothed spectra will be a combination of the library resolution
+practice the smoothed model spectra will be a combination of the library resolution
 plus whatever FFT smoothing is applied. Hopefully this can be made to match your
 actual data resolution, which is a combination of the physical velocity
 dispersion and the instrumental resolution. The smoothing is controlled by the
 parameters `sigma_smooth`, `smooth_type`, and `fftsmooth`
+
+For undersampled spectra, a special :py:class:`UnderSampledSpectrum` class
+exists that will integrate the model (smoothed by velocity dispersion and
+intrumental resolution) over the supplied pixels.
 
 
 Instrumental Response & Spectrophotometric Calibration
@@ -35,17 +39,17 @@ over the polynomial coefficients (this allows you to place priors on the
 accuracy of the spectrophotometric calibration). Or you can just take the
 spectrum as perfectly calibrated.
 
-Particular treatments can be implemented using different mixin classes, e.g.
+Particular treatments can be implemented using different mix-in classes, e.g.
 
 .. code-block:: python
 
         from prospect.observation import Spectrum, PolyOptCal
-        class PolySpect(PolyOptCal, Spectrum):
+        class PolySpectrum(PolyOptCal, Spectrum):
             pass
-        spec = PolySpect(wavelength=np.linspace(3000, 5000, N),
-                         flux=np.zeros(N),
-                         uncertainty=np.ones(N),
-                         polynomial_order=5)
+        spec = PolySpectrum(wavelength=np.linspace(3000, 5000, N),
+                            flux=np.zeros(N),
+                            uncertainty=np.ones(N),
+                            polynomial_order=5)
 
 
 Nebular emission

--- a/doc/spectra.rst
+++ b/doc/spectra.rst
@@ -1,0 +1,60 @@
+Fitting Spectra
+================
+
+There are several extra considerations that come up when fitting spectroscopy.
+
+Wavelength range, resolution, and linespread function
+-----------------------------------------------------
+
+Prospector is based on FSPS, which uses stellar spectral libraries with given
+resolution. The empirical MILES library has a resolution of ~2.5A FWHM from
+3750AA - 7200AA restframe, and much lower (R~200 or so, but not actually well
+defined) outside this range. Higher resolution data (after including both
+velocity dispersion and instrumental resolution) or spectral points outside this
+range cannot yet be fit.
+
+Prospector includes methods for FFT based smoothing of the spectra, assuming a
+gaussian LSF (in either wavelength or velocity space). There is also the
+possibility of FFT based smoothing for wavelength dependent Gaussian dispersion
+(i.e. sigma_lambda = f(lambda) with f possibly a polynomial of lambda). In
+practice the smoothed spectra will be a combination of the library resolution
+plus whatever FFT smoothing is applied. Hopefully this can be made to match your
+actual data resolution, which is a combination of the physical velocity
+dispersion and the instrumental resolution. The smoothing is controlled by the
+parameters `sigma_smooth`, `smooth_type`, and `fftsmooth`
+
+
+Instrumental Response & Spectrophotometric Calibration
+---------------------
+
+There are various options for dealing with the spectral continuum shape
+depending on how well you think your spectra are calibrated and if you also fit
+photometry to tie down the continuum shape. You can optimize out a polynomial
+"calibration" vector, or simultaneously fit for a polynomial and marginalize
+over the polynomial coefficients (this allows you to place priors on the
+accuracy of the spectrophotometric calibration). Or you can just take the
+spectrum as perfectly calibrated.
+
+Particular treatments can be implemented using different mixin classes, e.g.
+
+.. code-block:: python
+
+        from prospect.observation import Spectrum, PolyOptCal
+        class PolySpect(PolyOptCal, Spectrum):
+            pass
+        spec = PolySpect(wavelength=np.linspace(3000, 5000, N),
+                         flux=np.zeros(N),
+                         uncertainty=np.ones(N),
+                         polynomial_order=5)
+
+
+Nebular emission
+----------------
+
+While prospector/FSPS include self-consistent nebular emission, the treatment is
+probably not flexible enough at the moment to fit high S/N, high resolution data
+including nebular emission (e.g. due to deviations of line ratios from Cloudy
+predictions or to complicated gas kinematics that are different than stellar
+kinematics). Thus fitting nebular lines should take adavantage of the nebular
+line amplitude optimization/marginalization capabilities. For very low
+resolution data this is less of an issue.

--- a/prospect/io/read_results.py
+++ b/prospect/io/read_results.py
@@ -240,9 +240,9 @@ def get_sps(res):
                   "same as the FSPS libraries that you are using now ({})".format(flib, rlib))
         # If fitting and reading in are happening in different python versions,
         # ensure string comparison doesn't throw error:
-        if type(flib[0]) == 'bytes':
+        if isinstance(flib[0], bytes):
             flib = [i.decode() for i in flib]
-        if type(rlib[0]) == 'bytes':
+        if isinstance(rlib[0], bytes):
             rlib = [i.decode() for i in rlib]
         assert (flib[0] == rlib[0]) and (flib[1] == rlib[1]), liberr
 

--- a/prospect/io/write_results.py
+++ b/prospect/io/write_results.py
@@ -279,7 +279,7 @@ def chain_to_struct(chain, model=None, names=None, **extras):
     struct :
         A structured ndarray of parameter values.
     """
-    indict = type(chain) == dict
+    indict = isinstance(chain, dict)
     if indict:
         return dict_to_struct(chain)
     else:

--- a/prospect/models/__init__.py
+++ b/prospect/models/__init__.py
@@ -6,14 +6,13 @@ specifications.
 """
 
 
-from .sedmodel import ProspectorParams, SpecModel
-from .sedmodel import PolySpecModel, SplineSpecModel
-from .sedmodel import AGNSpecModel
+from .parameters import ProspectorParams
+from .sedmodel import SpecModel, HyperSpecModel, AGNSpecModel
 
 
 __all__ = ["ProspectorParams",
            "SpecModel",
-           "PolySpecModel", "SplineSpecModel",
-           "LineSpecModel", "AGNSpecModel"
+           "HyperSpecModel",
+           "AGNSpecModel"
            ]
 

--- a/prospect/models/sedmodel.py
+++ b/prospect/models/sedmodel.py
@@ -205,7 +205,7 @@ class SpecModel(ProspectorParams):
 
         return inst_spec
 
-    def predict_spec(self, obs, **extras):
+    def predict_spec(self, obs):
         """Generate a prediction for the observed spectrum.  This method assumes
         that the parameters have been set and that the following attributes are
         present and correct
@@ -285,8 +285,9 @@ class SpecModel(ProspectorParams):
             inst_spec[emask] += self._fix_eline_spec.sum(axis=1)
 
         # --- (de-) apply calibration ---
-        #self._speccal = self.spec_calibration(obs=obs, spec=inst_spec, **extras)
-        response = obs.get_calibration_vector(spec=inst_spec)
+        response = obs.compute_response(spec=inst_spec,
+                                        extra_mask=self._fit_eline_pixelmask,
+                                        **self.params)
         inst_spec = inst_spec * response
 
         # --- fit and add lines if necessary ---
@@ -805,9 +806,6 @@ class SpecModel(ProspectorParams):
         x = 2.0 * (x / (x[mask]).max()) - 1.0
         return x
 
-    def spec_calibration(self, **kwargs):
-        return np.ones_like(self._outwave)
-
     def absolute_rest_maggies(self, filterset):
         """Return absolute rest-frame maggies (=10**(-0.4*M)) of the last
         computed spectrum.
@@ -841,160 +839,6 @@ class SpecModel(ProspectorParams):
             abs_rest_maggies += emaggies
 
         return abs_rest_maggies
-
-
-class PolySpecModel(SpecModel):
-
-    """This is a subclass of *SpecModel* that generates the multiplicative
-    calibration vector at each model `predict` call as the maximum likelihood
-    chebyshev polynomial describing the ratio between the observed and the model
-    spectrum.
-    """
-
-    def _available_parameters(self):
-        # These should both be attached to the Observation instance as attributes
-        pars = [("polynomial_order", "order of the polynomial to fit"),
-                ("polynomial_regularization", "vector of length `polyorder` providing regularization for each polynomial term"),
-                ("median_polynomial", "if > 0, median smooth with a kernel of width order/range/median_polynomial before fitting")
-                ]
-
-        return pars
-
-    def spec_calibration(self, theta=None, obs=None, spec=None, **kwargs):
-        """Implements a Chebyshev polynomial calibration model. This uses
-        least-squares to find the maximum-likelihood Chebyshev polynomial of a
-        certain order describing the ratio of the observed spectrum to the model
-        spectrum, conditional on all other parameters. If emission lines are
-        being marginalized out, they are excluded from the least-squares fit.
-
-        Parameters
-        ----------
-        obs :  Instance of `Spectrum`
-
-        spec : ndarray of shape (nwave,)
-            The model spectrum.
-
-        Returns
-        -------
-        cal : ndarray of shape (nwave,)
-           A polynomial given by :math:`\sum_{m=0}^M a_{m} * T_m(x)`.
-        """
-        if theta is not None:
-            self.set_parameters(theta)
-
-        # polynomial order and regularization, from the obs object or overridden from the model params
-        order = np.squeeze(getattr(obs, "polynomial_order", 0))
-        order = np.squeeze(self.params.get('polyorder', order))
-        reg = np.squeeze(getattr(obs, "polynomial_regularization", 0.))
-        reg = self.params.get('poly_regularization', reg)
-
-        polyopt = ((order > 0) &
-                   (obs.get('spectrum', None) is not None))
-        if polyopt:
-            # generate mask
-            # remove region around emission lines if doing analytical marginalization
-            mask = obs.get('mask', np.ones_like(obs['wavelength'], dtype=bool)).copy()
-            if self.params.get('marginalize_elines', False):
-                mask[self._fit_eline_pixelmask] = 0
-
-            # map unmasked wavelengths to the interval -1, 1
-            # masked wavelengths may have x>1, x<-1
-            x = self.wave_to_x(obs["wavelength"], mask)
-            y = (obs['spectrum'] / spec)[mask] - 1.0
-
-            if self.params.get('median_polynomial', 0) > 0:
-                kernel_factor = self.params["median_polynomial"]
-                knl = int((x.max() - x.min()) / order / kernel_factor)
-                knl += int((knl % 2) == 0)
-                y = medfilt(y, knl)
-            yerr = (obs['unc'] / spec)[mask]
-            yvar = yerr**2
-            A = chebvander(x[mask], order)
-            ATA = np.dot(A.T, A / yvar[:, None])
-            if np.any(reg > 0):
-                ATA += reg**2 * np.eye(order+1)
-            ATAinv = np.linalg.inv(ATA)
-            c = np.dot(ATAinv, np.dot(A.T, y / yvar))
-            Afull = chebvander(x, order)
-            poly = np.dot(Afull, c)
-            self._poly_coeffs = c
-        else:
-            poly = np.zeros_like(self._outwave)
-
-        return (1.0 + poly)
-
-
-class SplineSpecModel(SpecModel):
-
-    """This is a subclass of *SpecModel* that generates the multiplicative
-    calibration vector at each model `predict` call as the maximum likelihood
-    cubic spline describing the ratio between the observed and the model
-    spectrum.
-    """
-
-    def _available_parameters(self):
-        pars = [("spline_knot_wave", "vector of wavelengths for the location of the spline knots"),
-                ("spline_knot_spacing", "spacing between knots, in units of wavelength"),
-                ("spline_knot_n", "number of interior knots between minimum and maximum unmasked wavelength")
-                ]
-
-        return pars
-
-    def spec_calibration(self, theta=None, obs=None, spec=None, **kwargs):
-        """Implements a spline calibration model.  This fits a cubic spline with
-        determined knot locations to the ratio of the observed spectrum to the
-        model spectrum.  If emission lines are being marginalized out, they are
-        excluded from the least-squares fit.
-
-        The knot locations must be specified as model parameters, either
-        explicitly or via a number of knots or knot spacing (in angstroms)
-        """
-        if theta is not None:
-            self.set_parameters(theta)
-
-        splineopt = True
-        if splineopt:
-            mask, (wlo, whi) = self.obs_to_mask(obs)
-            y = (obs['spectrum'] / spec)[mask] - 1.0
-            yerr = (obs['unc'] / spec)[mask]  # HACK
-            knots_x = self.make_knots(wlo, whi, as_x=True, **self.params)
-            x = 2.0 * (obs["wavelength"] - wlo) / (whi - wlo) - 1.0
-            tck = splrep(x[mask], y[mask], w=1/yerr[mask], k=3, task=-1, t=knots_x)
-            self._spline_coeffs = tck
-            spl = BSpline(*tck)
-            spline = spl(x)
-        else:
-            spline = np.zeros_like(self._outwave)
-        return (1.0 + spline)
-
-    def make_knots(self, wlo, whi, as_x=True, **params):
-        """
-        """
-        if "spline_knot_wave" in params:
-            knots = np.squeeze(params["spline_knot_wave"])
-        elif "spline_knot_spacing" in params:
-            s = np.squeeze(params["spline_knot_spacing"])
-            # we drop the start so knots are interior
-            knots = np.arange(wlo, whi, s)[1:]
-        elif "spline_knot_n" in params:
-            n = np.squeeze(params["spline_knot_n"])
-            # we need to drop the endpoints so knots are interior
-            knots = np.linspace(wlo, whi, n)[1:-1]
-        else:
-            raise KeyError("No valid spline knot specification in self.params")
-
-        if as_x:
-            knots = 2.0 * (knots - wlo) / (whi - wlo) - 1.0
-
-        return knots
-
-    def obs_to_mask(self, obs):
-        mask = obs.get('mask', np.ones_like(obs['wavelength'], dtype=bool)).copy()
-        if self.params.get('marginalize_elines', False):
-            mask[self._fit_eline_pixelmask] = 0
-        w = obs["wavelength"]
-        wrange = w[mask].min(), w[mask].max()
-        return mask, wrange
 
 
 class AGNSpecModel(SpecModel):
@@ -1034,7 +878,7 @@ class AGNSpecModel(SpecModel):
         assert np.abs(self.emline_info["wave"][59] - 4863) < 2
         self._aline_lum[ainds] = afluxes
 
-    def predict_spec(self, obs, **extras):
+    def predict_spec(self, obs):
         """Generate a prediction for the observed spectrum.  This method assumes
         that the parameters have been set and that the following attributes are
         present and correct
@@ -1110,13 +954,13 @@ class AGNSpecModel(SpecModel):
             smooth_spec[emask] += self._agn_eline_spec
 
         # --- calibration ---
-        self._speccal = self.spec_calibration(obs=obs, spec=smooth_spec, **extras)
-        calibrated_spec = smooth_spec * self._speccal
+        response = obs.compute_response(spec=smooth_spec, **self.params)
+        inst_spec = smooth_spec * response
 
         # --- cache intrinsic spectrum ---
-        self._sed = calibrated_spec / self._speccal
+        self._sed = inst_spec / response
 
-        return calibrated_spec
+        return inst_spec
 
     def predict_lines(self, obs, **extras):
         """Generate a prediction for the observed nebular line fluxes, including
@@ -1200,53 +1044,8 @@ class AGNSpecModel(SpecModel):
         return aline_spec
 
 
-class PolyFitModel(SpecModel):
-
-    """This is a subclass of :py:class:`SpecModel` that generates the
-    multiplicative calibration vector as a Chebyshev polynomial described by the
-    ``'poly_coeffs'`` parameter of the model, which may be free (fittable)
-    """
-
-    def spec_calibration(self, theta=None, obs=None, **kwargs):
-        """Implements a Chebyshev polynomial calibration model.  This only
-        occurs if ``"poly_coeffs"`` is present in the :py:attr:`params`
-        dictionary, otherwise the value of ``params["spec_norm"]`` is returned.
-
-        :param theta: (optional)
-            If given, set :py:attr:`params` using this vector before
-            calculating the calibration polynomial. ndarray of shape
-            ``(ndim,)``
-
-        :param obs:
-            A dictionary of observational data, must contain the key
-            ``"wavelength"``
-
-        :returns cal:
-           If ``params["cal_type"]`` is ``"poly"``, a polynomial given by
-           :math:`\times (\Sum_{m=0}^M```'poly_coeffs'[m]``:math:` \times T_n(x))`.
-        """
-        if theta is not None:
-            self.set_parameters(theta)
-
-        if ('poly_coeffs' in self.params):
-            mask = obs.get('mask', slice(None))
-            # map unmasked wavelengths to the interval -1, 1
-            # masked wavelengths may have x>1, x<-1
-            x = self.wave_to_x(obs["wavelength"], mask)
-            # get coefficients.
-            c = self.params['poly_coeffs']
-            poly = chebval(x, c)
-            return poly
-        else:
-            return 1.0
-
-
 class HyperSpecModel(ProspectorHyperParams, SpecModel):
     pass
-
-class HyperPolySpecModel(ProspectorHyperParams, PolySpecModel):
-    pass
-
 
 
 def ln_mvn(x, mean=None, cov=None):

--- a/prospect/models/sedmodel.py
+++ b/prospect/models/sedmodel.py
@@ -285,8 +285,9 @@ class SpecModel(ProspectorParams):
             inst_spec[emask] += self._fix_eline_spec.sum(axis=1)
 
         # --- (de-) apply calibration ---
-        self._speccal = self.spec_calibration(obs=obs, spec=inst_spec, **extras)
-        inst_spec = inst_spec * self._speccal
+        #self._speccal = self.spec_calibration(obs=obs, spec=inst_spec, **extras)
+        response = obs.get_calibration_vector(spec=inst_spec)
+        inst_spec = inst_spec * response
 
         # --- fit and add lines if necessary ---
         emask = self._fit_eline_pixelmask
@@ -300,7 +301,7 @@ class SpecModel(ProspectorParams):
             inst_spec[emask] += self._fit_eline_spec.sum(axis=1)
 
         # --- cache intrinsic spectrum for this observation ---
-        self._sed = inst_spec / self._speccal
+        self._sed.append(inst_spec / response)
 
         return inst_spec
 

--- a/prospect/observation/__init__.py
+++ b/prospect/observation/__init__.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 
 from .observation import Observation
-from .observation import Photometry, Spectrum, Lines, UndersampledSpectrum, IntrinsicSpectrum
+from .observation import Photometry, Spectrum, Lines
+from .observation import UndersampledSpectrum, IntrinsicSpectrum
+from .observation import PolyOptCal, SplineOptCal
 from .observation import from_oldstyle, from_serial
 
 __all__ = ["Observation",
            "Photometry", "Spectrum", "Lines",
            "UndersampledSpectrum", "InstrinsicSpectrum",
+           "PolyOptCal", "SplineOptCal",
            "from_oldstyle", "from_serial"]

--- a/prospect/observation/observation.py
+++ b/prospect/observation/observation.py
@@ -440,7 +440,7 @@ class Spectrum(Observation):
         return outspec_padded[self._unpadded_inds]
 
 
-    def instrumental_response(self, **extras):
+    def compute_response(self, **extras):
         if self.response is not None:
             return self.response
         else:

--- a/prospect/observation/observation.py
+++ b/prospect/observation/observation.py
@@ -447,7 +447,6 @@ class Spectrum(Observation):
             return 1.0
 
 
-
 class Lines(Spectrum):
 
     _kind = "lines"
@@ -532,10 +531,10 @@ class PolyOptCal:
                  polynomial_regularization=0,
                  median_polynomial=0,
                  **kwargs):
-        super(PolyOptCal, self).__init(*args, **kwargs)
+        super(PolyOptCal, self).__init__(*args, **kwargs)
         self.polynomial_order = polynomial_order
         self.polynomial_regularization = polynomial_regularization
-        self.median_molynomial = median_polynomial
+        self.median_polynomial = median_polynomial
 
     def _available_parameters(self):
         # These should both be attached to the Observation instance as attributes
@@ -573,7 +572,8 @@ class PolyOptCal:
         assert (self.mask.sum() > order), f"Not enough points to constrain polynomial of order {order}"
 
         polyopt = (order > 0)
-        if ~polyopt:
+        if (not polyopt):
+            print("no polynomial")
             self.response = np.ones_like(self.wavelength)
             return self.response
 
@@ -614,7 +614,7 @@ class SplineOptCal:
                  spline_knot_spacing=None,
                  spline_knot_n=None,
                  **kwargs):
-        super(SplineOptCal, self).__init(*args, **kwargs)
+        super(SplineOptCal, self).__init__(*args, **kwargs)
 
         self.params = {}
         if spline_knot_wave is not None:

--- a/prospect/observation/observation.py
+++ b/prospect/observation/observation.py
@@ -46,7 +46,7 @@ class Observation:
     noise :
     """
 
-    kind = "observation"
+    _kind = "observation"
     logify_spectrum = False
     alias = {}
     _meta = ("kind", "name")

--- a/prospect/observation/observation.py
+++ b/prospect/observation/observation.py
@@ -3,6 +3,10 @@
 import json
 import numpy as np
 
+from numpy.polynomial.chebyshev import chebval, chebvander
+from scipy.interpolate import splrep, BSpline
+from scipy.signal import medfilt
+
 from sedpy.observate import FilterSet
 from sedpy.smoothing import smooth_fft
 from sedpy.observate import rebin
@@ -13,6 +17,7 @@ from ..likelihood.noise_model import NoiseModel
 __all__ = ["Observation",
            "Spectrum", "Photometry", "Lines",
            "UndersampledSpectrum", "IntrinsicSpectrum",
+           "SplineOptCal", "PolyOptCal",
            "from_oldstyle", "from_serial", "obstypes"]
 
 
@@ -288,12 +293,12 @@ class Spectrum(Observation):
 
     _meta = ("kind", "name", "lambda_pad")
     _data = ("wavelength", "flux", "uncertainty", "mask",
-             "resolution", "calibration")
+             "resolution", "response")
 
     def __init__(self,
                  wavelength=None,
                  resolution=None,
-                 calibration=None,
+                 response=None,
                  name=None,
                  lambda_pad=100,
                  polynomial_order=0.,
@@ -322,11 +327,9 @@ class Spectrum(Observation):
         super(Spectrum, self).__init__(name=name, **kwargs)
         self.lambda_pad = lambda_pad
         self.resolution = resolution
-        self.calibration = calibration
+        self.response = response
         self.instrument_smoothing_parameters = dict(smoothtype="vel", fftsmooth=True)
         self.wavelength = wavelength
-        self.polynomial_order = polynomial_order
-        self.polynomial_regularization = 0.
 
     @property
     def wavelength(self):
@@ -437,25 +440,12 @@ class Spectrum(Observation):
         return outspec_padded[self._unpadded_inds]
 
 
-class UndersampledSpectrum(Spectrum):
-    """
-    As for Spectrum, but account for pixelization effects when pixels
-    undersamplesthe instrumental LSF.
-    """
+    def instrumental_response(self, **extras):
+        if self.response is not None:
+            return self.response
+        else:
+            return 1.0
 
-    def _pixelize(self, outwave, inwave, influx):
-        return rebin(outwave, inwave, influx)
-
-
-class IntrinsicSpectrum(Spectrum):
-
-    """
-    As for Spectrum, but predictions for this object type will not include
-    polynomial fitting or fitting of the emission line strengths (previously fit
-    and cached emission luminosities will be used.)
-    """
-
-    _kind = "intrinsic"
 
 
 class Lines(Spectrum):
@@ -473,6 +463,7 @@ class Lines(Spectrum):
 
     def __init__(self,
                  line_ind=None,
+                 line_names=None,
                  name=None,
                  **kwargs):
 
@@ -496,76 +487,255 @@ class Lines(Spectrum):
             dispersion (:math:`= c \, \sigma_\lambda / \lambda = c \, \FWHM_\lambda / 2.355 / \lambda = c / (2.355 \, R_\lambda)`
             where :math:`c=2.998e5 {\rm km}/{\rm s}`
 
+        line_ind : iterable of string, optional
+            Names of the lines.
+
         :param calibration:
             not sure yet ....
         """
         super(Lines, self).__init__(name=name, resolution=None, **kwargs)
         assert (line_ind is not None), "You must identify the lines by their index in the FSPS emission line array"
         self.line_ind = np.array(line_ind).as_type(int)
+        self.line_names = line_names
 
 
+class UndersampledSpectrum(Spectrum):
+    """
+    As for Spectrum, but account for pixelization effects when pixels
+    undersamplesthe instrumental LSF.
+    """
+    #TODO: Implement as a convolution with a square kernel (or sinc in frequency space)
 
-class PolyCal:
+    def _pixelize(self, outwave, inwave, influx):
+        return rebin(outwave, inwave, influx)
 
-    def spec_calibration(self, theta=None, obs=None, spec=None, **kwargs):
-        """Implements a Chebyshev polynomial calibration model. This uses
+
+class IntrinsicSpectrum(Spectrum):
+
+    """
+    As for Spectrum, but predictions for this object type will not include
+    polynomial fitting or fitting of the emission line strengths (previously fit
+    and cached emission luminosities will be used.)
+    """
+
+    _kind = "intrinsic"
+
+
+class PolyOptCal:
+
+    """A mixin class that allows for optimization of a Chebyshev response
+    function given a model spectrum.
+    """
+
+    def __init__(self, *args,
+                 polynomial_order=0,
+                 polynomial_regularization=0,
+                 median_polynomial=0,
+                 **kwargs):
+        super(PolyOptCal, self).__init(*args, **kwargs)
+        self.polynomial_order = polynomial_order
+        self.polynomial_regularization = polynomial_regularization
+        self.median_molynomial = median_polynomial
+
+    def _available_parameters(self):
+        # These should both be attached to the Observation instance as attributes
+        pars = [("polynomial_order", "order of the polynomial to fit"),
+                ("polynomial_regularization", "vector of length `polyorder` providing regularization for each polynomial term"),
+                ("median_polynomial", "if > 0, median smooth with a kernel of width order/range/median_polynomial before fitting")
+                ]
+
+        return pars
+
+    def compute_response(self, spec=None, extra_mask=True, **kwargs):
+        """Implements a Chebyshev polynomial response function model. This uses
         least-squares to find the maximum-likelihood Chebyshev polynomial of a
         certain order describing the ratio of the observed spectrum to the model
-        spectrum, conditional on all other parameters. If emission lines are
-        being marginalized out, they are excluded from the least-squares fit.
+        spectrum. If emission lines are being marginalized out, they should be
+        excluded from the least-squares fit using the ``extra_mask`` keyword
 
         Parameters
         ----------
-        obs :  Instance of `Spectrum`
+        spec : ndarray of shape (Spectrum().ndata,)
+            The model spectrum on the observed wavelength grid
 
-        spec : ndarray of shape (nwave,)
-            The model spectrum.
+        extra_mask : ndarray of Booleans of shape (Spectrum().ndata,)
+            The extra mask to be applied.  True=use data, False=mask data
 
         Returns
         -------
-        cal : ndarray of shape (nwave,)
+        response : ndarray of shape (nwave,)
            A polynomial given by :math:`\sum_{m=0}^M a_{m} * T_m(x)`.
         """
-        if theta is not None:
-            self.set_parameters(theta)
 
-        #order = np.squeeze(self.params.get('polyorder', 0))
-        order = np.squeeze(getattr(obs, "polynomial_order", 0))
-        reg = np.squeeze(getattr(obs, "poly_regularization", 0))
-        polyopt = ((order > 0) &
-                   (obs.get('spectrum', None) is not None))
-        if polyopt:
-            # generate mask
-            # remove region around emission lines if doing analytical marginalization
-            mask = obs.get('mask', np.ones_like(obs['wavelength'], dtype=bool)).copy()
-            if self.params.get('marginalize_elines', False):
-                mask[self._fit_eline_pixelmask] = 0
+        order = self.polynomial_order
+        reg = self.polynomial_regularization
+        mask = self.mask & extra_mask
+        assert (self.mask.sum() > order), f"Not enough points to constrain polynomial of order {order}"
 
+        polyopt = (order > 0)
+        if ~polyopt:
+            self.response = np.ones_like(self.wavelength)
+            return self.response
+
+        x = wave_to_x(self.wavelength, mask)
+        y = (self.flux / spec - 1.0)[mask]
+        yerr = (self.uncertainty / spec)[mask]
+        yvar = yerr**2
+
+        if self.median_polynomial > 0:
+            kernel_factor = self.median_polynomial
+            knl = int((x.max() - x.min()) / order / kernel_factor)
+            knl += int((knl % 2) == 0)
+            y = medfilt(y, knl)
+
+        Afull = chebvander(x, order)
+        A = Afull[mask, :]
+        ATA = np.dot(A.T, A / yvar[:, None])
+        if np.any(reg > 0):
+            ATA += reg**2 * np.eye(order+1)
+        c = np.linalg.solve(ATA, np.dot(A.T, y / yvar))
+
+        poly = np.dot(Afull, c)
+
+        self._chebyshev_coefficients = c
+        self.response = poly + 1.0
+        return self.response
+
+
+class SplineOptCal:
+
+    """A mixin class that allows for optimization of a Chebyshev response
+    function given a model spectrum.
+    """
+
+
+    def __init__(self, *args,
+                 spline_knot_wave=None,
+                 spline_knot_spacing=None,
+                 spline_knot_n=None,
+                 **kwargs):
+        super(SplineOptCal, self).__init(*args, **kwargs)
+
+        self.params = {}
+        if spline_knot_wave is not None:
+            self.params["spline_knot_wave"] = spline_knot_wave
+        elif spline_knot_spacing is not None:
+            self.params["spline_knot_spacing"] = spline_knot_spacing
+        elif spline_knot_n is not None:
+            self.params["spline_knot_n"] = spline_knot_n
+
+        # build and cache the knots
+        w = self.wavelength[self.mask]
+        (wlo, whi) = w.min(), w.min()
+        self.wave_x = 2.0 * (self.wavelength - wlo) / (whi - wlo) - 1.0
+        self.knots_x = self.make_knots(wlo, whi, as_x=True, **self.params)
+
+
+    def _available_parameters(self):
+        pars = [("spline_knot_wave", "vector of wavelengths for the location of the spline knots"),
+                ("spline_knot_spacing", "spacing between knots, in units of wavelength"),
+                ("spline_knot_n", "number of interior knots between minimum and maximum unmasked wavelength")
+                ]
+
+        return pars
+
+    def compute_response(self, spec=None, extra_mask=True, **extras):
+        """Implements a spline response function model.  This fits a cubic
+        spline with determined knot locations to the ratio of the observed
+        spectrum to the model spectrum.  If emission lines are being
+        marginalized out, they are excluded from the least-squares fit.
+
+        The knot locations must be specified as model parameters, either
+        explicitly or via a number of knots or knot spacing (in angstroms)
+        """
+        mask = self.mask & extra_mask
+
+
+        splineopt = True
+        if ~splineopt:
+            self.response = np.ones_like(self.wavelength)
+            return self.response
+
+        y = (self.flux / spec - 1.0)[mask]
+        yerr = (self.uncertainty / spec)[mask] # HACK
+        tck = splrep(self.wave_x[mask], y[mask], w=1/yerr[mask], k=3, task=-1, t=self.knots_x)
+        self._spline_coeffs = tck
+        spl = BSpline(*tck)
+        spline = spl(self.wave_x)
+
+        self.response = (1.0 + spline)
+        return self.response
+
+    def make_knots(self, wlo, whi, as_x=True, **params):
+        """Can we move this to instantiation?
+        """
+        if "spline_knot_wave" in params:
+            knots = np.squeeze(params["spline_knot_wave"])
+        elif "spline_knot_spacing" in params:
+            s = np.squeeze(params["spline_knot_spacing"])
+            # we drop the start so knots are interior
+            knots = np.arange(wlo, whi, s)[1:]
+        elif "spline_knot_n" in params:
+            n = np.squeeze(params["spline_knot_n"])
+            # we need to drop the endpoints so knots are interior
+            knots = np.linspace(wlo, whi, n)[1:-1]
+        else:
+            raise KeyError("No valid spline knot specification in self.params")
+
+        if as_x:
+            knots = 2.0 * (knots - wlo) / (whi - wlo) - 1.0
+
+        return knots
+
+
+class PolyFitCal:
+
+    """This is a mixin class that generates the
+    multiplicative response vector as a Chebyshev polynomial described by the
+    ``poly_param_name`` parameter of the model, which may be free (fittable)
+    """
+
+    def __init__(self, *args, poly_param_name=None, **kwargs):
+        super(SplineOptCal, self).__init(*args, **kwargs)
+        self.poly_param_name = poly_param_name
+
+    def _available_parameters(self):
+        pars = [(self.poly_param_name, "vector of polynomial chabyshev coefficients")]
+
+        return pars
+
+    def compute_response(self, **kwargs):
+        """Implements a Chebyshev polynomial calibration model.  This only
+        occurs if ``"poly_coeffs"`` is present in the :py:attr:`params`
+        dictionary, otherwise the value of ``params["spec_norm"]`` is returned.
+
+        :param theta: (optional)
+            If given, set :py:attr:`params` using this vector before
+            calculating the calibration polynomial. ndarray of shape
+            ``(ndim,)``
+
+        :param obs:
+            A dictionary of observational data, must contain the key
+            ``"wavelength"``
+
+        :returns cal:
+           If ``params["cal_type"]`` is ``"poly"``, a polynomial given by
+           :math:`\times (\Sum_{m=0}^M```'poly_coeffs'[m]``:math:` \times T_n(x))`.
+        """
+
+        if self.poly_param_name in kwargs:
+            mask = self.get('mask', slice(None))
             # map unmasked wavelengths to the interval -1, 1
             # masked wavelengths may have x>1, x<-1
-            x = self.wave_to_x(obs["wavelength"], mask)
-            y = (obs['spectrum'] / spec)[mask] - 1.0
-
-            if self.params.get('median_polynomial', 0) > 0:
-                kernel_factor = self.params["median_polynomial"]
-                knl = int((x.max() - x.min()) / order / kernel_factor)
-                knl += int((knl % 2) == 0)
-                y = medfilt(y, knl)
-            yerr = (obs['unc'] / spec)[mask]
-            yvar = yerr**2
-            A = chebvander(x[mask], order)
-            ATA = np.dot(A.T, A / yvar[:, None])
-            if np.any(reg > 0):
-                ATA += reg**2 * np.eye(order+1)
-            ATAinv = np.linalg.inv(ATA)
-            c = np.dot(ATAinv, np.dot(A.T, y / yvar))
-            Afull = chebvander(x, order)
-            poly = np.dot(Afull, c)
-            self._poly_coeffs = c
+            x = wave_to_x(self.wavelength, mask)
+            # get coefficients.
+            c = kwargs[self.poly_param_name]
+            poly = chebval(x, c)
         else:
-            poly = np.zeros_like(self._outwave)
+            poly = 1.0
 
-        return (1.0 + poly)
+        self.response = poly
+        return self.response
 
 
 obstypes = dict(photometry=Photometry,
@@ -600,3 +770,11 @@ def from_serial(arr, meta):
 
     return obs
 
+
+def wave_to_x(wavelength=None, mask=slice(None), **extras):
+    """Map unmasked wavelengths to the interval -1, 1
+            masked wavelengths may have x>1, x<-1
+    """
+    x = wavelength - (wavelength[mask]).min()
+    x = 2.0 * (x / (x[mask]).max()) - 1.0
+    return x

--- a/tests/test_polycal.py
+++ b/tests/test_polycal.py
@@ -54,7 +54,7 @@ def build_obs(multispec=False):
     return obslist
 
 
-def test_polycal(plot=False):
+def test_polycal(get_sps, plot=False):
     """Make sure the polynomial optimization works
     """
     sps = get_sps

--- a/tests/test_polycal.py
+++ b/tests/test_polycal.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import pytest
+
+from prospect.sources import CSPSpecBasis
+from prospect.models import SpecModel, templates
+from prospect.observation import Spectrum, Photometry, PolyOptCal
+
+
+class PolySpectrum(PolyOptCal, Spectrum):
+    pass
+
+
+
+@pytest.fixture
+def get_sps():
+    sps = CSPSpecBasis(zcontinuous=1)
+    return sps
+
+
+def build_model(add_neb=False):
+    model_params = templates.TemplateLibrary["parametric_sfh"]
+    if add_neb:
+        model_params.update(templates.TemplateLibrary["nebular"])
+    return SpecModel(model_params)
+
+
+def build_obs(multispec=False):
+    N = 1500 * (2 - multispec)
+    wmax = 7000
+    wsplit = wmax - N * multispec
+
+    fnames = list([f"sdss_{b}0" for b in "ugriz"])
+    Nf = len(fnames)
+    phot = [Photometry(filters=fnames,
+                       flux=np.ones(Nf),
+                       uncertainty=np.ones(Nf)/10)]
+    spec = [PolySpectrum(wavelength=np.linspace(4000, wsplit, N),
+                         flux=np.ones(N),
+                         uncertainty=np.ones(N) / 10,
+                         mask=slice(None),
+                         polynomial_order=5)
+            ]
+
+    if multispec:
+        spec += [Spectrum(wavelength=np.linspace(wsplit+1, wmax, N),
+                          flux=np.ones(N), uncertainty=np.ones(N) / 10,
+                          mask=slice(None))]
+
+    obslist = spec + phot
+    [obs.rectify() for obs in obslist]
+    return obslist
+
+
+def test_polycal(plot=False):
+    """Make sure the polynomial optimization works
+    """
+    sps = get_sps
+    observations = build_obs()
+    model = build_model()
+
+    preds, extra = model.predict(model.theta, observations=observations, sps=sps)
+    obs = observations[0]
+
+    assert np.any(obs.response != 0)
+
+    if plot:
+        import matplotlib.pyplot as pl
+        fig, axes = pl.subplots(3, 1, sharex=True)
+        ax = axes[0]
+        ax.plot(obs.wavelength, obs.flux, label="obseved flux (ones)")
+        ax.plot(obs.wavelength, preds[0], label="model flux (times response)")
+        ax = axes[1]
+        ax.plot(obs.wavelength, obs.response, label="instrumental response (polynomial)")
+        ax = axes[2]
+        ax.plot(obs.wavelength, preds[0]/ obs.response, label="intrinsic model spectrum")
+        ax.set_xlabel("wavelength")
+        [ax.legend() for ax in axes]


### PR DESCRIPTION
This moves responsibility for the spectroscopic instrumental response to individual `Spectrum()` instances, via mixin classes.  It also improves some documentation, and moves code common to multiple prediction types to a dedicated method. 