### PR TITLE
fix for numpy 2.0

### DIFF
--- a/prospect/plotting/corner.py
+++ b/prospect/plotting/corner.py
@@ -305,7 +305,7 @@ def corner(samples, paxes, weights=None, span=None, smooth=0.02,
     :returns paxes:
     """
     assert samples.ndim > 1
-    assert np.product(samples.shape[1:]) > samples.shape[0]
+    assert np.prod(samples.shape[1:]) > samples.shape[0]
     ndim = len(samples)
 
     # Determine plotting bounds.


### PR DESCRIPTION
I believe the current version of prospector is incompatible with the new numpy>=2.0 releases since `numpy.product` has been deprecated. The fix is straightforward: replace `numpy.product` with `numpy.prod`. I hope this makes sense. There may be other parts of the code that need to be adjusted, as well.