### PR TITLE
working with empty Spectrum object

### DIFF
--- a/prospect/likelihood/noise_model.py
+++ b/prospect/likelihood/noise_model.py
@@ -37,6 +37,9 @@ class NoiseModel:
 
     def lnlike(self, pred, obs, vectors={}):
 
+        if obs.flux is None:
+            return 0
+
         # populatate vectors used as metrics and weight functions.
         vectors = self.populate_vectors(obs)
         # Construct Sigma (and factorize if 2d)

--- a/prospect/observation/observation.py
+++ b/prospect/observation/observation.py
@@ -101,9 +101,24 @@ class Observation:
         uncertainties.
         """
         n = self.__repr__
-        if self.flux is None:
-            print(f"{n} has no data")
-            return
+
+        _flux_array = False
+        try:
+            len(self.flux)
+            _flux_array = True
+        except:
+            _flux_array = False
+
+        if _flux_array:
+            if self.flux is None:
+                print(f"{n} has no data")
+                return
+        else:
+            if self.flux == None:
+                print(f"{n} has no data")
+                self.flux = None
+                self.wavelength = None
+                return
 
         assert self.flux.ndim == 1, f"{n}: flux is not a 1d array"
         assert self.uncertainty.ndim == 1, f"{n}: uncertainty is not a 1d array"
@@ -331,7 +346,10 @@ class Spectrum(Observation):
         self.resolution = resolution
         self.response = response
         self.instrument_smoothing_parameters = dict(smoothtype="vel", fftsmooth=True)
-        self.wavelength = np.atleast_1d(wavelength)
+        if wavelength is not None:
+            self.wavelength = np.atleast_1d(wavelength)
+        else:
+            self.wavelength = None
 
     @property
     def wavelength(self):


### PR DESCRIPTION
First attempt to allow for an empty object in obs. I am just creating this PR in case it would be helpful when we are ready to solve this problem properly; i.e., we don't necessarily need to merge this (especially given that I am not entirely sure I know what I am doing with p-v2...). Note that this version does not solve all the errors; specifically, this error remains when writing to an h5 file in `observation.py, in to_struct`:

> if (len(dat) != self.ndata):
>     TypeError: len() of unsized object

But I am less familiar with the io part....