### PR TITLE
Enable user-selectable cosmology and update default to `Planck18`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,97 @@
-manual*
-*tex
-.vscode
-*.pyc
-__pycache__
+# --------------------------------------------------------------------------------------
+# STANDARD PYTHON IGNORES
+# --------------------------------------------------------------------------------------
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Sphinx documentation
+docs/_build/
+
+# Jupyter Notebook
 .ipynb_checkpoints
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+
+# PyCharm / VS Code (Optional, usually good to keep)
+.idea/
+.vscode/
+
+# --------------------------------------------------------------------------------------
+# PROSPECTOR SPECIFIC IGNORES
+# --------------------------------------------------------------------------------------
+
+# Generated version file
+_version.py
+
+# Scientific data formats
 *.h5
 *.fits
-*egg*
-build/
+
+# Manuscript / LaTeX
+manual*
+*tex
+
+# Project directories
 _build/
-dist/
 demo/*/
 misc/
 detritus/

--- a/prospect/models/templates.py
+++ b/prospect/models/templates.py
@@ -11,6 +11,7 @@ import os
 from . import priors
 from . import priors_beta
 from . import transforms, hyperparam_transforms
+from ..sources.constants import default_cosmo, beta_cosmo
 
 __all__ = ["TemplateLibrary",
            "describe",
@@ -169,9 +170,11 @@ par_name = {"N": 1,
 
 imf = {"N": 1, "isfree": False, "init": 2}        # Kroupa
 dust_type = {"N": 1, "isfree": False, "init": 0}  # Power-law
+cosmology = {"N": 1, "isfree": False, "init": default_cosmo, "units": "Astropy Cosmology"}
 
 _defaults_ = {"imf_type": imf,        # FSPS parameter
-              "dust_type": dust_type  # FSPS parameter
+              "dust_type": dust_type, # FSPS parameter
+              "cosmology": cosmology,
               }
 
 TemplateLibrary["type_defaults"] = (_defaults_,
@@ -811,8 +814,11 @@ _beta_nzsfh_["mass"] = {'N': nbins_sfh, 'isfree': False, 'init': 1e6, 'units': r
                         'depends_on': transforms.logsfr_ratios_to_masses}
 
 _beta_nzsfh_['agebins'] = {'N': nbins_sfh, 'isfree': False,
-                           'init': transforms.zred_to_agebins_pbeta(np.atleast_1d(0.5), np.zeros(nbins_sfh)),
+                           'init': transforms.zred_to_agebins_pbeta(np.atleast_1d(0.5), np.zeros(nbins_sfh), cosmology['init']),
                            'depends_on': transforms.zred_to_agebins_pbeta}
+
+# Prospector-Beta must use WMAP9 cosmology due to tabulated data being used
+_beta_nzsfh_['cosmology']['init'] = beta_cosmo
 
 TemplateLibrary["beta"] = (_beta_nzsfh_,
                            "The prospector-beta model; Wang, Leja, et al. 2023: https://ui.adsabs.harvard.edu/abs/2023ApJ...944L..58W/abstract")

--- a/prospect/plotting/sfh.py
+++ b/prospect/plotting/sfh.py
@@ -8,7 +8,6 @@ import numpy as np
 from scipy.special import gamma, gammainc
 
 from ..models.transforms import logsfr_ratios_to_masses
-from ..sources.constants import cosmo
 from .corner import quantile
 
 try:

--- a/prospect/sources/constants.py
+++ b/prospect/sources/constants.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 try:
-    from astropy.cosmology import WMAP9 as cosmo
+    from astropy.cosmology import Planck18 as cosmo
 except(ImportError):
     cosmo = None
 

--- a/prospect/sources/constants.py
+++ b/prospect/sources/constants.py
@@ -1,15 +1,14 @@
 import numpy as np
 
-try:
-    from astropy.cosmology import Planck18 as cosmo
-except(ImportError):
-    cosmo = None
+from astropy.cosmology import Planck18 as default_cosmo
+from astropy.cosmology import WMAP9 as beta_cosmo
+cosmo = default_cosmo # Alias for backward compatibility
 
 __all__ = ['lsun', 'pc', 'lightspeed', 'ckms',
            'jansky_mks', 'jansky_cgs',
            'to_cgs_at_10pc', 'loge',
            'kboltz', 'hplanck',
-           'cosmo']
+           'default_cosmo', 'beta_cosmo', 'cosmo']
 
 # Useful constants
 lsun = 3.846e33  # erg/s

--- a/tests/test_cosmology.py
+++ b/tests/test_cosmology.py
@@ -1,0 +1,135 @@
+import numpy as np
+import pytest
+from astropy.cosmology import Planck18, WMAP9
+
+from prospect.models import SpecModel
+from prospect.models.templates import TemplateLibrary
+from prospect.models.transforms import tage_from_tuniv, zred_to_agebins
+
+
+class DummySPS:
+    def get_galaxy_spectrum(self, **kwargs):
+        return np.linspace(3000, 8000, 100), np.ones(100), 1.0
+
+    def get_galaxy_elines(self):
+        return np.array([3727, 5007]), np.array([1.0, 1.0])
+
+    @property
+    def spectral_resolution(self):
+        return 0.0
+
+
+def test_default_cosmology():
+    """Test that the default cosmology is Planck18."""
+    model_params = TemplateLibrary["ssp"]
+    model = SpecModel(model_params)
+
+    # Check if cosmology parameter exists and is Planck18
+    assert "cosmology" in model.params
+    # Unwrapping checks
+    cosmo = model.params["cosmology"]
+    if isinstance(cosmo, np.ndarray):
+        cosmo = cosmo.item()
+    assert cosmo.name == Planck18.name
+
+    # Verify flux_norm uses this cosmology
+    # We can check luminosity distance indirectly or spy on it, but checking the object is strong indication
+
+    # Let's check calculations
+    z = 1.0
+    tage_p18 = tage_from_tuniv(zred=z, tage_tuniv=1.0, cosmology=Planck18)
+    tage_default = tage_from_tuniv(
+        zred=z, tage_tuniv=1.0, cosmology=None
+    )  # Should use default which we set to Planck18 in constants
+
+    # In transforms.py, if cosmology is None, it imports from constants.py
+    # In constants.py, we set default to Planck18
+    assert np.isclose(tage_p18, tage_default)
+
+
+def test_custom_cosmology():
+    """Test using a custom cosmology (WMAP9)."""
+    model_params = TemplateLibrary["ssp"]
+    model_params["cosmology"] = {
+        "N": 1,
+        "isfree": False,
+        "init": WMAP9,
+        "units": "Astropy Cosmology",
+    }
+    model = SpecModel(model_params)
+
+    cosmo = model.params["cosmology"]
+    if isinstance(cosmo, np.ndarray):
+        cosmo = cosmo.item()
+    assert cosmo.name == WMAP9.name
+
+    # Verify calculations differ from Planck18
+    z = 1.0
+    tage_wmap9 = tage_from_tuniv(zred=z, tage_tuniv=1.0, cosmology=WMAP9)
+    tage_p18 = tage_from_tuniv(zred=z, tage_tuniv=1.0, cosmology=Planck18)
+
+    assert not np.isclose(tage_wmap9, tage_p18)
+
+    # Verify model uses WMAP9 logic in flux_norm
+    model.params["zred"] = np.array([1.0])
+    model._zred = model.params["zred"][
+        0
+    ]  # Manually set _zred as it's usually done in predict_init
+
+    # SpecModel.flux_norm calls cosmo.luminosity_distance(z)
+    norm = model.flux_norm()
+
+    # Manually calculate expected norm with WMAP9
+    lumdist = WMAP9.luminosity_distance(1.0).to("Mpc").value
+    dfactor = (lumdist * 1e5) ** 2
+    to_cgs_at_10pc = 3.846e33 / (4.0 * np.pi * (3.085677581467192e18 * 10) ** 2)
+    jansky_cgs = 1e-23
+    unit_conversion = to_cgs_at_10pc / (3631 * jansky_cgs) * (1 + 1.0)
+    expected_norm = 1e10 * unit_conversion / dfactor  # mass is 1e10 by default
+
+    assert np.isclose(norm, expected_norm)
+
+
+def test_unwrapping_transforms():
+    """Test that transforms handle wrapped cosmology objects."""
+    z = 0.5
+
+    # Wrapped cosmology
+    wrapped_cosmo = np.array([Planck18], dtype=object)
+
+    # Test tage_from_tuniv
+    tage_unwrapped = tage_from_tuniv(zred=z, tage_tuniv=1.0, cosmology=Planck18)
+    tage_wrapped = tage_from_tuniv(zred=z, tage_tuniv=1.0, cosmology=wrapped_cosmo)
+    assert tage_unwrapped == tage_wrapped
+
+    # Test zred_to_agebins
+    # Provide multiple bins to avoid index error in zred_to_agebins logic
+    agebins = np.array([[0, 8], [8, 9], [9, 10]])
+    bins_unwrapped = zred_to_agebins(zred=z, agebins=agebins, cosmology=Planck18)
+    bins_wrapped = zred_to_agebins(zred=z, agebins=agebins, cosmology=wrapped_cosmo)
+    np.testing.assert_array_equal(bins_unwrapped, bins_wrapped)
+
+
+def test_sedmodel_unwrapping():
+    """Test that SpecModel unwraps cosmology correctly."""
+    model_params = TemplateLibrary["ssp"]
+
+    model = SpecModel(model_params)
+    model.params["cosmology"] = np.array([Planck18], dtype=object)
+    model.params["zred"] = np.array([0.1])
+    model._zred = model.params["zred"][0]
+
+    # This should not raise an error
+    try:
+        model.flux_norm()
+    except AttributeError as e:
+        pytest.fail(f"SpecModel.flux_norm raised AttributeError: {e}")
+    except Exception as e:
+        pytest.fail(f"SpecModel.flux_norm raised unexpected exception: {e}")
+
+
+if __name__ == "__main__":
+    test_default_cosmology()
+    test_custom_cosmology()
+    test_unwrapping_transforms()
+    test_sedmodel_unwrapping()

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -355,7 +355,9 @@ class TestParameterDependencies:
         from prospect.models import transforms
 
         expected_agebins = transforms.zred_to_agebins_pbeta(
-            np.atleast_1d(new_zred), np.zeros(7)
+            np.atleast_1d(new_zred),
+            np.zeros(7),
+            model.params["cosmology"],
         )  # 7 bins default
         assert np.allclose(model.params["agebins"], expected_agebins), (
             "agebins not updated correctly from new zred"


### PR DESCRIPTION
### Description

Fixes #171

This PR refactors the codebase to treat cosmology as a configurable model parameter (`model.params['cosmology']`) rather than a hard-coded global constant.

Previously, Prospector was hard-coded to use `WMAP9` (Hinshaw et al. [2013](https://ui.adsabs.harvard.edu/abs/2014A%26A...571A..16P/abstract)) via `astropy`. This PR updates the default cosmology to `Planck18` (Planck Collaboration [2018](https://ui.adsabs.harvard.edu/abs/2020A%26A...641A...6P/abstract)) to match modern simulations and survey parameters, while allowing users to inject custom `astropy.cosmology` objects (e.g., `FlatLambdaCDM`, `Planck15`) via the parameter file.

### Changes Implemented

#### 1. Cosmology Parameterization

* **Model Integration:** Added `cosmology` to the default parameter templates in `prospect/models/templates.py`. It is now stored in `model.params` alongside physics parameters.
* **`SpecModel` Logic:** Added a `@property` to `SpecModel` in `prospect/models/sedmodel.py` that retrieves the cosmology object. This property handles the necessary "unwrapping" of the object (as `ProspectorParams` wraps all inputs in NumPy arrays).
* **Transform Functions:** Updated helper functions in `prospect/models/transforms.py` (e.g., `zred_to_agebins`, `tage_from_tuniv`) to accept an optional `cosmology` argument.

#### 2. Physics & Defaults

* **New Default:** Updated the global default in `prospect/sources/constants.py` from `WMAP9` to `Planck18`.
* **Prospector-*β* Constraint:** Explicitly pinned the `beta` and `beta_phisfh` templates in `prospect/models/templates.py` to use `WMAP9`. This is mathematically required because the Prospector-*β* prior data (specifically the redshift-age relationship tables in `prospect/models/prior_data/wmap9_z_age.txt`) was generated using WMAP9.

#### 3. Maintenance & Compatibility

* **Backward Compatibility:** Retained a `cosmo` alias in `prospect/sources/constants.py` and implemented fallback logic in transform functions. Existing scripts that do not specify a cosmology parameter will default gracefully to `Planck18` without raising errors.
* **Gitignore:** Updated `.gitignore` to use the standard Python GitHub template while preserving project-specific rules (e.g., `*.h5`, `manual*`, `demo/*/`).

### Verification

I have added a new test module `tests/test_cosmology.py` that verifies:

* **Default Behavior:** Ensures models initialized without explicit cosmology parameters default correctly to `Planck18`.
* **Customization:** Verifies that passing a `WMAP9` object in `model_params` alters derived properties (e.g., luminosity distance, age of universe) compared to the default.
* **NumPy Unwrapping:** Explicitly tests the robust handling of wrapped object arrays within `SpecModel` and transforms, preventing `AttributeError` when accessing cosmology methods.

### Checklist

* [x] Refactor `SpecModel` and `transforms` to accept cosmology objects.
* [x] Update `TemplateLibrary` defaults.
* [x] Default Prospector-*β* to `WMAP9` to ensure consistency with prior data.
* [x] Add backward compatibility fallbacks in `constants.py`.
* [x] Add unit tests for cosmology selection and object unwrapping.
* [ ] Allow Prospector-*β* to use cosmologies other than `WMAP9` (maybe?).
* [x] Update `.gitignore`.
* [ ] Update documentation.