### PR TITLE
Sampler keyword inspection

### DIFF
--- a/prospect/fitting/fitting.py
+++ b/prospect/fitting/fitting.py
@@ -432,6 +432,7 @@ def run_nested(observations, model, sps,
                nested_nlive=1000,
                nested_target_n_effective=1000,
                verbose=False,
+               return_object=False,
                **kwargs):
     """Thin wrapper on :py:class:`prospect.fitting.nested.run_nested_sampler`
 
@@ -454,12 +455,16 @@ def run_nested(observations, model, sps,
         ``model``, and ``sps`` as keywords. By default use the
         :py:func:`lnprobfn` defined above.
 
-    nested_target_n_effective : int
-        Target number of effective samples
-
     nested_nlive : int
         Number of live points for the nested sampler.  Meaning somewhat
         dependent on the chosen sampler
+
+    nested_target_n_effective : int
+        Target number of effective samples
+
+    return_object : bool (optional, default: False)
+        If ``True``, return the sampler result object as an entry in the
+        output dictionary.
 
     Returns
     --------
@@ -483,5 +488,8 @@ def run_nested(observations, model, sps,
                                 nested_neff=nested_target_n_effective,
                                 **kwargs)
     info, result_obj = output
+
+    if return_object:
+        info["sampler_result_object"] = result_obj
 
     return info

--- a/prospect/fitting/fitting.py
+++ b/prospect/fitting/fitting.py
@@ -432,7 +432,7 @@ def run_nested(observations, model, sps,
                nested_nlive=1000,
                nested_target_n_effective=1000,
                verbose=False,
-               return_object=False,
+               return_sampler_result_object=False,
                **kwargs):
     """Thin wrapper on :py:class:`prospect.fitting.nested.run_nested_sampler`
 
@@ -462,7 +462,7 @@ def run_nested(observations, model, sps,
     nested_target_n_effective : int
         Target number of effective samples
 
-    return_object : bool (optional, default: False)
+    return_sampler_result_object : bool (optional, default: False)
         If ``True``, return the sampler result object as an entry in the
         output dictionary.
 
@@ -489,7 +489,7 @@ def run_nested(observations, model, sps,
                                 **kwargs)
     info, result_obj = output
 
-    if return_object:
+    if return_sampler_result_object:
         info["sampler_result_object"] = result_obj
 
     return info

--- a/tests/tests_samplers.py
+++ b/tests/tests_samplers.py
@@ -11,6 +11,7 @@ from prospect.sources import CSPSpecBasis
 from prospect.models import SpecModel, templates
 from prospect.observation import Photometry
 from prospect.fitting import fit_model
+from prospect.fitting.fitting import run_nested
 from prospect.io.write_results import write_hdf5
 from prospect.io.read_results import results_from
 
@@ -76,6 +77,19 @@ if __name__ == "__main__":
     # do a first model caching
     (phot,), mfrac = model.predict(model.theta, obs, sps=sps)
     print(model)
+
+    # test passing sampler-specific kwargs
+    sampler = "nautilus"
+    run_params["nested_sampler"] = sampler
+    run_params["n_like_max"] = 100 # speed
+    # just to make sure we will get out exactly n_like_max points
+    assert run_params["nested_nlive"] > run_params["n_like_max"]
+    out = run_nested(obs, model, sps, return_object=True, **run_params)
+    _ = run_params.pop("n_like_max")
+    res = out["sampler_object"]
+    assert res.n_like == 100
+    assert len(out["points"]) == 100
+
 
     # loop over samplers
     results = {}

--- a/tests/tests_samplers.py
+++ b/tests/tests_samplers.py
@@ -84,12 +84,11 @@ if __name__ == "__main__":
     run_params["n_like_max"] = 100 # speed
     # just to make sure we will get out exactly n_like_max points
     assert run_params["nested_nlive"] > run_params["n_like_max"]
-    out = run_nested(obs, model, sps, return_object=True, **run_params)
+    out = run_nested(obs, model, sps, return_sampler_result_object=True, **run_params)
     _ = run_params.pop("n_like_max")
-    res = out["sampler_object"]
+    res = out["sampler_result_object"]
     assert res.n_like == 100
     assert len(out["points"]) == 100
-
 
     # loop over samplers
     results = {}


### PR DESCRIPTION
This PR fixes an issue with passing of sampler specific keywords for nested sampling.

It also makes it easier to surface the full nested sampler results object (by setting `run_params["return_object"] = True`)