### PR TITLE
fix: replace deprecated imp.new_module with types.ModuleType

### DIFF
--- a/prospect/io/read_results.py
+++ b/prospect/io/read_results.py
@@ -281,8 +281,8 @@ def get_model(res):
 def import_module_from_string(source, name, add_to_sys_modules=True):
     """Well this seems dangerous.
     """
-    import imp
-    user_module = imp.new_module(name)
+    import types
+    user_module = types.ModuleType(name)
     exec(source, user_module.__dict__)
     if add_to_sys_modules:
         sys.modules[name] = user_module


### PR DESCRIPTION
The `imp` module has been deprecated since Python 3.4 and was removed entirely in Python 3.12. This replaces our remaining use of `imp.new_module()` so the code runs on Python versions >= 3.12.
```python
# Before
import imp
user_module = imp.new_module(name)

# After
import types
user_module = types.ModuleType(name)
```

`types.ModuleType` is the type of module objects, and calling it with a name produces a fresh empty module — the same result `imp.new_module` returned. The behavior is identical, so no other changes are needed. This is the just the replacement by definition:
```python
def new_module(name):
    import types

    """**DEPRECATED**

    Create a new module.

    The module is not entered into sys.modules.

    """
    return types.ModuleType(name)
```

Many thanks to @duanqiao-astro for figuring this out together.